### PR TITLE
IslandWestCave1 Definitions

### DIFF
--- a/stardew-access/assets/static-tiles.json
+++ b/stardew-access/assets/static-tiles.json
@@ -950,6 +950,38 @@
       "type": "door"
     }
   },
+  "islandwestcave1": {
+    "Lion Statue": {
+      "x": [6],
+      "y": [2],
+      "type": "other"
+    },
+    "Crystal 1": {
+      "x": [3],
+      "y": [4],
+      "type": "interactable"
+    },
+    "Crystal 2": {
+      "x": [4],
+      "y": [6],
+      "type": "interactable"
+    },
+    "Crystal 3": {
+      "x": [6],
+      "y": [7],
+      "type": "interactable"
+    },
+    "Crystal 4": {
+      "x": [8],
+      "y": [6],
+      "type": "interactable"
+    },
+    "Crystal 5": {
+      "x": [9],
+      "y": [4],
+      "type": "interactable"
+    }
+  },
   "jojamart": {
     "Morris's Kiosk": {
       "x": [21],
@@ -2059,6 +2091,13 @@
     "Mutant Bug Lair": {
       "x": [3],
       "y": [19],
+      "type": "door"
+    }
+  },
+  "skullcave": {
+    "Skull Cavern Door": {
+      "x": [3],
+      "y": [3],
       "type": "door"
     }
   },


### PR DESCRIPTION
Added definitions to IslandWestCave1 for the lion statue and note crystals so players can resolve that puzzle.Reverted the removal of the skull cavern door in 1.3.4, since that's an interaction tile used to enter the actual dungeon.