### PR TITLE
Update harmony and Stardew.ModConfig; add newtonsoft.json as dependency.

### DIFF
--- a/stardew-access/stardew-access.csproj
+++ b/stardew-access/stardew-access.csproj
@@ -12,8 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lib.Harmony" Version="2.2.0" />
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.0.0" />
+    <PackageReference Include="Lib.Harmony" Version="2.2.2" />
+    <PackageReference Include="newtonsoft.json" Version="13.0.2" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.0" />
     <Reference Include="./TolkDotNet.dll" />
   </ItemGroup>
 


### PR DESCRIPTION
While setting up my development environment I ended up with newer versions of these dependencies. It wasn't causing problems but showing warnings at compile time.
After updating harmony Stardew-Access wasn't able to find newtonsoft.json so I had to add it directly.

The other patches compile (with warnings) if this patch is ignored.