### PR TITLE
Refactor i18n part 2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,3 @@ dotnet_diagnostic.IDE0051.severity = silent
 
 # IDE0060: Remove unused parameter
 dotnet_diagnostic.IDE0060.severity = silent
-
-# IDE1006: Naming Styles
-dotnet_diagnostic.IDE1006.severity = silent

--- a/stardew-access/API.cs
+++ b/stardew-access/API.cs
@@ -55,7 +55,7 @@ namespace stardew_access
         /// <returns>Name of the object as the first item (name) and category as the second item (category). Returns null if no object found.</returns>
         public static (string? name, string? category) GetNameWithCategoryNameAtTile(Vector2 tile)
         {
-            return TileInfo.getNameWithCategoryNameAtTile(tile, null);
+            return TileInfo.GetNameWithCategoryNameAtTile(tile, null);
         }
 
         /// <summary>

--- a/stardew-access/CustomCommands.cs
+++ b/stardew-access/CustomCommands.cs
@@ -348,7 +348,7 @@ namespace stardew_access
 
             helper.ConsoleCommands.Add("buildlist", "List all buildings for selection for upgrading/demolishing/painting", (string command, string[] args) =>
             {
-                onBuildListCalled();
+                OnBuildListCalled();
             });
 
             helper.ConsoleCommands.Add("buildsel", "Select the building index which you want to upgrade/demolish/paint", (string command, string[] args) =>
@@ -503,7 +503,7 @@ namespace stardew_access
             #endregion
         }
 
-        internal static void onBuildListCalled()
+        internal static void OnBuildListCalled()
         {
             string toPrint = "";
             Farm farm = (Farm)Game1.getLocationFromName("Farm");

--- a/stardew-access/Features/BuildingOperations.cs
+++ b/stardew-access/Features/BuildingOperations.cs
@@ -111,7 +111,7 @@ namespace stardew_access.Utils
             {
                 if (CarpenterMenuPatch.isOnFarm && Game1.locationRequest == null)
                 {
-                    if (tryToBuild(position))
+                    if (TryToBuild(position))
                     {
                         if (CarpenterMenuPatch.carpenterMenu != null)
                         {
@@ -131,7 +131,7 @@ namespace stardew_access.Utils
             return response;
         }
 
-        public static bool tryToBuild(Vector2 position)
+        public static bool TryToBuild(Vector2 position)
         {
             if (CarpenterMenuPatch.carpenterMenu == null)
                 return false;

--- a/stardew-access/Features/DynamicTiles.cs
+++ b/stardew-access/Features/DynamicTiles.cs
@@ -721,7 +721,7 @@ namespace stardew_access.Utils
 
             if (FeedingBenchBounds.TryGetValue(locationName, out var bounds) && x >= bounds.minX && x <= bounds.maxX && y == bounds.y)
             {
-                (string? name, CATEGORY category) = TileInfo.getObjectAtTile(currentLocation, x, y, true);
+                (string? name, CATEGORY category) = TileInfo.GetObjectAtTile(currentLocation, x, y, true);
                 return (Translator.Instance.Translate( "tile_name-feeding_bench" + (name?.Contains("hay", StringComparison.OrdinalIgnoreCase) == true ? "" : "_empty")), category);
             }
 

--- a/stardew-access/Features/GameStateNarrator.cs
+++ b/stardew-access/Features/GameStateNarrator.cs
@@ -14,7 +14,7 @@ namespace stardew_access.Utils
         /// <summary>
         /// Narrates the currently selected slot item when changing the selected slot.
         /// </summary>
-        public static void narrateCurrentSlot()
+        public static void NarrateCurrentSlot()
         {
             currentSlotItem = Game1.player.CurrentItem;
 
@@ -35,7 +35,7 @@ namespace stardew_access.Utils
         /// <summary>
         /// Narrates the current location name when moving to a new location.
         /// </summary>
-        public static void narrateCurrentLocation()
+        public static void NarrateCurrentLocation()
         {
             currentLocation = Game1.currentLocation;
 
@@ -56,7 +56,7 @@ namespace stardew_access.Utils
         /// <summary>
         /// Narrates the HUD messages.
         /// </summary>
-        public static void narrateHudMessages()
+        public static void NarrateHudMessages()
         {
             try
             {

--- a/stardew-access/Features/Radar.cs
+++ b/stardew-access/Features/Radar.cs
@@ -121,7 +121,7 @@ namespace stardew_access.Utils
                 {
                     Vector2 dir = new(item.X + dirX[i], item.Y + dirY[i]);
 
-                    if (isValid(dir, center, searched, limit))
+                    if (IsValid(dir, center, searched, limit))
                     {
                         toSearch.Enqueue(dir);
                         searched.Add(dir);
@@ -176,7 +176,7 @@ namespace stardew_access.Utils
                 {
                     Vector2 dir = new(item.X + dirX[i], item.Y + dirY[i]);
 
-                    if (!searched.Contains(dir) && (TileInfo.isWarpPointAtTile(currentLocation, (int)dir.X, (int)dir.Y) || currentLocation.isTileOnMap(dir)))
+                    if (!searched.Contains(dir) && (TileInfo.IsWarpPointAtTile(currentLocation, (int)dir.X, (int)dir.Y) || currentLocation.isTileOnMap(dir)))
                     {
                         toSearch.Enqueue(dir);
                         searched.Add(dir);
@@ -198,7 +198,7 @@ namespace stardew_access.Utils
         /// <param name="searched">The list of searched items.</param>
         /// <param name="limit">The radius of search</param>
         /// <returns>Returns true if the tile is valid for search.</returns>
-        public static bool isValid(Vector2 item, Vector2 center, HashSet<Vector2> searched, int limit)
+        public static bool IsValid(Vector2 item, Vector2 center, HashSet<Vector2> searched, int limit)
         {
             if (Math.Abs(item.X - center.X) > limit)
                 return false;
@@ -213,7 +213,7 @@ namespace stardew_access.Utils
 
         public static (bool, string? name, string category) CheckTile(Vector2 position, GameLocation currentLocation, bool lessInfo = false)
         {
-            (string? name, CATEGORY? category) = TileInfo.getNameWithCategoryAtTile(position, currentLocation, lessInfo);
+            (string? name, CATEGORY? category) = TileInfo.GetNameWithCategoryAtTile(position, currentLocation, lessInfo);
             if (name == null)
                 return (false, null, CATEGORY.Others.ToString());
 
@@ -229,7 +229,7 @@ namespace stardew_access.Utils
             {
                 if (currentLocation.isObjectAtTile((int)position.X, (int)position.Y))
                 {
-                    (string? name, CATEGORY category) objDetails = TileInfo.getObjectAtTile(currentLocation, (int)position.X, (int)position.Y);
+                    (string? name, CATEGORY category) objDetails = TileInfo.GetObjectAtTile(currentLocation, (int)position.X, (int)position.Y);
                     string? objectName = objDetails.name;
                     CATEGORY category = objDetails.category;
                     StardewValley.Object obj = currentLocation.getObjectAtTile((int)position.X, (int)position.Y);
@@ -253,7 +253,7 @@ namespace stardew_access.Utils
                 }
                 else
                 {
-                    (string? name, CATEGORY? category) = TileInfo.getNameWithCategoryAtTile(position, currentLocation);
+                    (string? name, CATEGORY? category) = TileInfo.GetNameWithCategoryAtTile(position, currentLocation);
                     if (name != null)
                     {
                         category ??= CATEGORY.Others;

--- a/stardew-access/Features/ReadTile.cs
+++ b/stardew-access/Features/ReadTile.cs
@@ -20,7 +20,7 @@ namespace stardew_access.Utils
             delay = 100;
         }
 
-        public void update()
+        public void Update()
         {
             if (this.isBusy)
                 return;
@@ -29,7 +29,7 @@ namespace stardew_access.Utils
                 return;
 
             this.isBusy = true;
-            this.run();
+            this.Run();
             Task.Delay(delay).ContinueWith(_ => { this.isBusy = false; });
         }
 
@@ -37,7 +37,7 @@ namespace stardew_access.Utils
         /// Pauses the feature for the provided time.
         /// </summary>
         /// <param name="time">The amount of time we want to pause the execution (in ms).<br/>Default is 2500 (2.5s).</param>
-        public void pauseUntil(int time = 2500)
+        public void PauseUntil(int time = 2500)
         {
             this.shouldPause = true;
             Task.Delay(time).ContinueWith(_ => { this.shouldPause = false; });
@@ -46,7 +46,7 @@ namespace stardew_access.Utils
         /// <summary>
         /// Pauses the feature
         /// </summary>
-        public void pause()
+        public void Pause()
         {
             this.shouldPause = true;
         }
@@ -54,12 +54,12 @@ namespace stardew_access.Utils
         /// <summary>
         /// Resumes the feature
         /// </summary>
-        public void resume()
+        public void Resume()
         {
             this.shouldPause = false;
         }
 
-        public void run(bool manuallyTriggered = false, bool playersPosition = false)
+        public void Run(bool manuallyTriggered = false, bool playersPosition = false)
         {
             try
             {
@@ -92,7 +92,7 @@ namespace stardew_access.Utils
                     var currentLocation = Game1.currentLocation;
                     bool isColliding = TileInfo.IsCollidingAtTile(currentLocation, x, y);
 
-                    (string? name, string? category) = TileInfo.getNameWithCategoryNameAtTile(tile, currentLocation);
+                    (string? name, string? category) = TileInfo.GetNameWithCategoryNameAtTile(tile, currentLocation);
 
                     #region Narrate toSpeak
                     if (name != null)

--- a/stardew-access/Features/TileViewer.cs
+++ b/stardew-access/Features/TileViewer.cs
@@ -95,43 +95,43 @@ namespace stardew_access.Utils
             }
             else if (MainClass.Config.TileCursorPreciseUpKey.JustPressed())
             {
-                this.cursorMoveInput(new Vector2(0, -MainClass.Config.TileCursorPreciseMovementDistance), true);
+                this.CursorMoveInput(new Vector2(0, -MainClass.Config.TileCursorPreciseMovementDistance), true);
             }
             else if (MainClass.Config.TileCursorPreciseRightKey.JustPressed())
             {
-                this.cursorMoveInput(new Vector2(MainClass.Config.TileCursorPreciseMovementDistance, 0), true);
+                this.CursorMoveInput(new Vector2(MainClass.Config.TileCursorPreciseMovementDistance, 0), true);
             }
             else if (MainClass.Config.TileCursorPreciseDownKey.JustPressed())
             {
-                this.cursorMoveInput(new Vector2(0, MainClass.Config.TileCursorPreciseMovementDistance), true);
+                this.CursorMoveInput(new Vector2(0, MainClass.Config.TileCursorPreciseMovementDistance), true);
             }
             else if (MainClass.Config.TileCursorPreciseLeftKey.JustPressed())
             {
-                this.cursorMoveInput(new Vector2(-MainClass.Config.TileCursorPreciseMovementDistance, 0), true);
+                this.CursorMoveInput(new Vector2(-MainClass.Config.TileCursorPreciseMovementDistance, 0), true);
             }
             else if (MainClass.Config.TileCursorUpKey.JustPressed())
             {
-                this.cursorMoveInput(new Vector2(0, -Game1.tileSize));
+                this.CursorMoveInput(new Vector2(0, -Game1.tileSize));
             }
             else if (MainClass.Config.TileCursorRightKey.JustPressed())
             {
-                this.cursorMoveInput(new Vector2(Game1.tileSize, 0));
+                this.CursorMoveInput(new Vector2(Game1.tileSize, 0));
             }
             else if (MainClass.Config.TileCursorDownKey.JustPressed())
             {
-                this.cursorMoveInput(new Vector2(0, Game1.tileSize));
+                this.CursorMoveInput(new Vector2(0, Game1.tileSize));
             }
             else if (MainClass.Config.TileCursorLeftKey.JustPressed())
             {
-                this.cursorMoveInput(new Vector2(-Game1.tileSize, 0));
+                this.CursorMoveInput(new Vector2(-Game1.tileSize, 0));
             }
             else if (MainClass.Config.AutoWalkToTileKey.JustPressed() && StardewModdingAPI.Context.IsPlayerFree)
             {
-                this.startAutoWalking();
+                this.StartAutoWalking();
             }
         }
 
-        private void startAutoWalking()
+        private void StartAutoWalking()
         {
             PathFindController controller = new(Game1.player, Game1.currentLocation, this.GetViewingTile().ToPoint(), Game1.player.FacingDirection)
             {
@@ -142,7 +142,7 @@ namespace stardew_access.Utils
                 Game1.player.controller = controller;
                 this.isAutoWalking = true;
                 this.finalTile = this.GetViewingTile();
-                MainClass.ReadTileFeature.pause();
+                MainClass.ReadTileFeature.Pause();
                 MainClass.ScreenReader.Say($"Moving to {this.finalTile.X}x {this.finalTile.Y}y", true);
             }
             else
@@ -155,19 +155,19 @@ namespace stardew_access.Utils
         /// Stop the auto walk controller and reset variables 
         /// </summary>
         /// <param name="wasForced">Narrates a message if set to true.</param>
-        public void stopAutoWalking(bool wasForced = false)
+        public void StopAutoWalking(bool wasForced = false)
         {
             this.finalTile = Vector2.Zero;
             this.isAutoWalking = false;
             Game1.player.controller = null;
-            MainClass.ReadTileFeature.resume();
+            MainClass.ReadTileFeature.Resume();
             if (wasForced)
                 MainClass.ScreenReader.Say("Stopped moving", true);
         }
 
-        private void cursorMoveInput(Vector2 delta, Boolean precise = false)
+        private void CursorMoveInput(Vector2 delta, Boolean precise = false)
         {
-            if (!tryMoveTileView(delta)) return;
+            if (!TryMoveTileView(delta)) return;
             Vector2 position = this.GetTileCursorPosition();
             Vector2 tile = this.GetViewingTile();
             String? name = TileInfo.GetNameAtTile(tile);
@@ -200,10 +200,10 @@ namespace stardew_access.Utils
             }
         }
 
-        private bool tryMoveTileView(Vector2 delta)
+        private bool TryMoveTileView(Vector2 delta)
         {
             Vector2 dest = this.GetTileCursorPosition() + delta;
-            if (!isPositionOnMap(dest)) return false;
+            if (!IsPositionOnMap(dest)) return false;
             if ((MainClass.Config.LimitTileCursorToScreen && Utility.isOnScreen(dest, 0)) || !MainClass.Config.LimitTileCursorToScreen)
             {
                 if (this.relativeOffsetLock)
@@ -222,7 +222,7 @@ namespace stardew_access.Utils
         private void SnapMouseToPlayer()
         {
             Vector2 cursorPosition = this.GetTileCursorPosition();
-            if (allowMouseSnap(cursorPosition))
+            if (AllowMouseSnap(cursorPosition))
                 // Must account for viewport here
                 Game1.setMousePosition((int)cursorPosition.X - Game1.viewport.X, (int)cursorPosition.Y - Game1.viewport.Y);
         }
@@ -230,7 +230,7 @@ namespace stardew_access.Utils
         /// <summary>
         /// Handle tile viewer logic.
         /// </summary>
-        public void update()
+        public void Update()
         {
             //Reset the viewing cursor to the player when they turn or move. This will not reset the locked offset relative cursor position.
             if (this.prevFacing != PlayerFacingVector || this.prevPlayerPosition != PlayerPosition)
@@ -253,13 +253,13 @@ namespace stardew_access.Utils
                 if (this.finalTile != Vector2.Zero && this.finalTile == CurrentPlayer.Position)
                 {
                     MainClass.ScreenReader.Say("Reached destination", true);
-                    this.stopAutoWalking();
+                    this.StopAutoWalking();
                 }
             }
 
         }
 
-        private static bool allowMouseSnap(Vector2 point)
+        private static bool AllowMouseSnap(Vector2 point)
         {
             // Prevent snapping if any menu is open
             if (Game1.activeClickableMenu != null) return false;
@@ -276,11 +276,11 @@ namespace stardew_access.Utils
             return true;
         }
 
-        private static bool isPositionOnMap(Vector2 position)
+        private static bool IsPositionOnMap(Vector2 position)
         {
             var currentLocation = Game1.currentLocation;
             // Check whether the position is a warp point, if so then return true, sometimes warp points are 1 tile off the map for example in coops and barns
-            if (TileInfo.isWarpPointAtTile(currentLocation, (int)(position.X / Game1.tileSize), (int)(position.Y / Game1.tileSize))) return true;
+            if (TileInfo.IsWarpPointAtTile(currentLocation, (int)(position.X / Game1.tileSize), (int)(position.Y / Game1.tileSize))) return true;
 
             //position does not take viewport into account since the entire map needs to be checked.
             Map map = currentLocation.map;

--- a/stardew-access/Features/Warnings.cs
+++ b/stardew-access/Features/Warnings.cs
@@ -17,17 +17,17 @@ namespace stardew_access.Utils
             prevHour = 6;
         }
 
-        public void update()
+        public void Update()
         {
-            this.checkForHealth();
-            this.checkForStamina();
-            this.checkForTimeOfDay();
+            this.CheckForHealth();
+            this.CheckForStamina();
+            this.CheckForTimeOfDay();
         }
 
         /// <summary>
         /// Warns when its past 12:00 am and 1:00 am
         /// </summary>
-        private void checkForTimeOfDay()
+        private void CheckForTimeOfDay()
         {
             if (MainClass.ModHelper == null)
                 return;
@@ -39,7 +39,7 @@ namespace stardew_access.Utils
             {
                 MainClass.ScreenReader.Say(toSpeak, true);
                 // Pause the read tile feature to prevent interruption in warning message
-                MainClass.ReadTileFeature.pauseUntil();
+                MainClass.ReadTileFeature.PauseUntil();
             }
 
             prevHour = hours;
@@ -48,7 +48,7 @@ namespace stardew_access.Utils
         /// <summary>
         /// Warns when stamina reaches below 50, 25 and 10.
         /// </summary>
-        public void checkForStamina()
+        public void CheckForStamina()
         {
             if (MainClass.ModHelper == null)
                 return;
@@ -60,7 +60,7 @@ namespace stardew_access.Utils
             {
                 MainClass.ScreenReader.Say(toSpeak, true);
                 // Pause the read tile feature to prevent interruption in warning message
-                MainClass.ReadTileFeature.pauseUntil();
+                MainClass.ReadTileFeature.PauseUntil();
             }
 
             prevStamina = stamina;
@@ -69,7 +69,7 @@ namespace stardew_access.Utils
         /// <summary>
         /// Warns when health reaches below 50, 25 and 10.
         /// </summary>
-        public void checkForHealth()
+        public void CheckForHealth()
         {
             if (MainClass.ModHelper == null)
                 return;
@@ -81,7 +81,7 @@ namespace stardew_access.Utils
             {
                 MainClass.ScreenReader.Say(toSpeak, true);
                 // Pause the read tile feature to prevent interruption in warning message
-                MainClass.ReadTileFeature.pauseUntil();
+                MainClass.ReadTileFeature.PauseUntil();
             }
 
             prevHealth = health;

--- a/stardew-access/ModEntry.cs
+++ b/stardew-access/ModEntry.cs
@@ -144,7 +144,7 @@ namespace stardew_access
             TextBoxPatch.activeTextBoxes = "";
             if (e.OldMenu != null)
             {
-                MainClass.DebugLog($"Switched from {e.OldMenu.GetType().ToString()} menu, performing cleanup...");
+                MainClass.DebugLog($"Switched from {e.OldMenu.GetType()} menu, performing cleanup...");
                 IClickableMenuPatch.Cleanup(e.OldMenu);
             }
         }

--- a/stardew-access/ModEntry.cs
+++ b/stardew-access/ModEntry.cs
@@ -129,9 +129,9 @@ namespace stardew_access
 
             helper.Events.GameLoop.GameLaunched += this.OnGameLaunched;
             helper.Events.Input.ButtonPressed += this.OnButtonPressed;
-            helper.Events.GameLoop.UpdateTicked += this.onUpdateTicked;
-            helper.Events.GameLoop.DayStarted += this.onDayStarted;
-            helper.Events.Display.MenuChanged += this.onMenuChanged;
+            helper.Events.GameLoop.UpdateTicked += this.OnUpdateTicked;
+            helper.Events.GameLoop.DayStarted += this.OnDayStarted;
+            helper.Events.Display.MenuChanged += this.OnMenuChanged;
             AppDomain.CurrentDomain.DomainUnload += OnExit;
             AppDomain.CurrentDomain.ProcessExit += OnExit;
         }
@@ -139,7 +139,7 @@ namespace stardew_access
         private void OnGameLaunched(object? sender, GameLaunchedEventArgs e) => Translator.Instance.Initialize(ModManifest);
 
 
-        private void onMenuChanged(object? sender, MenuChangedEventArgs e)
+        private void OnMenuChanged(object? sender, MenuChangedEventArgs e)
         {
             TextBoxPatch.activeTextBoxes = "";
             if (e.OldMenu != null)
@@ -159,29 +159,29 @@ namespace stardew_access
             ScreenReader?.CloseScreenReader();
         }
 
-        private void onDayStarted(object? sender, DayStartedEventArgs? e)
+        private void OnDayStarted(object? sender, DayStartedEventArgs? e)
         {
             StaticTiles.LoadTilesFiles();
             StaticTiles.SetupTilesDicts();
         }
 
-        private void onUpdateTicked(object? sender, UpdateTickedEventArgs? e)
+        private void OnUpdateTicked(object? sender, UpdateTickedEventArgs? e)
         {
             if (!Context.IsPlayerFree)
                 return;
 
             // Narrates currently selected inventory slot
-            GameStateNarrator.narrateCurrentSlot();
+            GameStateNarrator.NarrateCurrentSlot();
             // Narrate current location's name
-            GameStateNarrator.narrateCurrentLocation();
+            GameStateNarrator.NarrateCurrentLocation();
             //handle TileCursor update logic
-            TileViewerFeature.update();
+            TileViewerFeature.Update();
 
             if (Config.Warning)
-                WarningsFeature.update();
+                WarningsFeature.Update();
 
             if (Config.ReadTile)
-                ReadTileFeature.update();
+                ReadTileFeature.Update();
 
             RunRadarFeatureIfEnabled();
 
@@ -205,7 +205,7 @@ namespace stardew_access
                 if (!isNarratingHudMessage)
                 {
                     isNarratingHudMessage = true;
-                    GameStateNarrator.narrateHudMessages();
+                    GameStateNarrator.NarrateHudMessages();
                     await Task.Delay(300);
                     isNarratingHudMessage = false;
                 }
@@ -219,7 +219,7 @@ namespace stardew_access
                     {
                         prevDate = CurrentPlayer.Date;
                         DebugLog("Refreshing buildlist...");
-                        CustomCommands.onBuildListCalled();
+                        CustomCommands.OnBuildListCalled();
                     }
                 }
             }
@@ -255,7 +255,7 @@ namespace stardew_access
             }
 
             #region Simulate left and right clicks
-            if (!TextBoxPatch.isAnyTextBoxActive)
+            if (!TextBoxPatch.IsAnyTextBoxActive)
             {
                 if (Game1.activeClickableMenu != null)
                 {
@@ -290,7 +290,7 @@ namespace stardew_access
             // Stops the auto walk   controller if any movement key(WASD) is pressed
             if (TileViewerFeature.isAutoWalking && IsMovementKey(e.Button))
             {
-                TileViewerFeature.stopAutoWalking(wasForced: true);
+                TileViewerFeature.StopAutoWalking(wasForced: true);
             }
 
             // Narrate Current Location
@@ -357,14 +357,14 @@ namespace stardew_access
             // Manual read tile at player's position
             if (Config.ReadStandingTileKey.JustPressed())
             {
-                ReadTileFeature.run(manuallyTriggered: true, playersPosition: true);
+                ReadTileFeature.Run(manuallyTriggered: true, playersPosition: true);
                 return;
             }
 
             // Manual read tile at looking tile
             if (Config.ReadTileKey.JustPressed())
             {
-                ReadTileFeature.run(manuallyTriggered: true);
+                ReadTileFeature.Run(manuallyTriggered: true);
                 return;
             }
 

--- a/stardew-access/Patches/BundleMenuPatches/JojaCDMenuPatch.cs
+++ b/stardew-access/Patches/BundleMenuPatches/JojaCDMenuPatch.cs
@@ -22,11 +22,11 @@ namespace stardew_access.Patches
 
                     if (c.name.Equals("complete"))
                     {
-                        toSpeak = $"Completed {getNameFromIndex(i)}";
+                        toSpeak = $"Completed {GetNameFromIndex(i)}";
                     }
                     else
                     {
-                        toSpeak = $"{getNameFromIndex(i)} Cost: {__instance.getPriceFromButtonNumber(i)}g Description: {__instance.getDescriptionFromButtonNumber(i)}";
+                        toSpeak = $"{GetNameFromIndex(i)} Cost: {__instance.getPriceFromButtonNumber(i)}g Description: {__instance.getDescriptionFromButtonNumber(i)}";
                     }
 
                     break;
@@ -44,7 +44,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static string getNameFromIndex(int i)
+        private static string GetNameFromIndex(int i)
         {
             string name = i switch
             {

--- a/stardew-access/Patches/BundleMenuPatches/JunimoNoteMenuPatch.cs
+++ b/stardew-access/Patches/BundleMenuPatches/JunimoNoteMenuPatch.cs
@@ -17,12 +17,12 @@ namespace stardew_access.Patches
             {
                 int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position
 
-                if (narrateJunimoArea(__instance, ___specificBundlePage, ___whichArea, x, y))
+                if (NarrateJunimoArea(__instance, ___specificBundlePage, ___whichArea, x, y))
                 {
                     return;
                 }
 
-                narrateBundlePage(__instance, ___specificBundlePage, ___currentPageBundle, x, y);
+                NarrateBundlePage(__instance, ___specificBundlePage, ___currentPageBundle, x, y);
             }
             catch (Exception e)
             {
@@ -30,7 +30,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static bool narrateJunimoArea(JunimoNoteMenu __instance, bool ___specificBundlePage, int ___whichArea, int x, int y)
+        private static bool NarrateJunimoArea(JunimoNoteMenu __instance, bool ___specificBundlePage, int ___whichArea, int x, int y)
         {
             if (___specificBundlePage)
                 return false;
@@ -94,7 +94,7 @@ namespace stardew_access.Patches
             return false;
         }
 
-        private static void narrateBundlePage(JunimoNoteMenu __instance, bool ___specificBundlePage, Bundle ___currentPageBundle, int x, int y)
+        private static void NarrateBundlePage(JunimoNoteMenu __instance, bool ___specificBundlePage, Bundle ___currentPageBundle, int x, int y)
         {
             if (!___specificBundlePage)
                 return;
@@ -109,19 +109,19 @@ namespace stardew_access.Patches
             if (isIPressed && !isUsingCustomKeyBinds)
             {
                 isUsingCustomKeyBinds = true;
-                cycleThroughIngredientList(__instance, ___currentPageBundle, isLeftShiftPressed);
+                CycleThroughIngredientList(__instance, ___currentPageBundle, isLeftShiftPressed);
                 Task.Delay(200).ContinueWith(_ => { isUsingCustomKeyBinds = false; });
             }
             else if (isVPressed && !isUsingCustomKeyBinds)
             {
                 isUsingCustomKeyBinds = true;
-                cycleThroughInputSlots(__instance, ___currentPageBundle, isLeftShiftPressed);
+                CycleThroughInputSlots(__instance, ___currentPageBundle, isLeftShiftPressed);
                 Task.Delay(200).ContinueWith(_ => { isUsingCustomKeyBinds = false; });
             }
             else if (isCPressed && !isUsingCustomKeyBinds)
             {
                 isUsingCustomKeyBinds = true;
-                cycleThroughInventorySlots(__instance, ___currentPageBundle, isLeftShiftPressed);
+                CycleThroughInventorySlots(__instance, ___currentPageBundle, isLeftShiftPressed);
                 Task.Delay(200).ContinueWith(_ => { isUsingCustomKeyBinds = false; });
             }
             else if (isBackPressed && __instance.backButton != null && !__instance.backButton.containsPoint(x, y))
@@ -137,7 +137,7 @@ namespace stardew_access.Patches
             return;
         }
 
-        private static void cycleThroughIngredientList(JunimoNoteMenu __instance, Bundle ___currentPageBundle, bool isLeftShiftPressed = false)
+        private static void CycleThroughIngredientList(JunimoNoteMenu __instance, Bundle ___currentPageBundle, bool isLeftShiftPressed = false)
         {
             if (___currentPageBundle.ingredients.Count < 0)
                 return;
@@ -194,7 +194,7 @@ namespace stardew_access.Patches
             MainClass.ScreenReader.Say(toSpeak, true);
         }
 
-        private static void cycleThroughInputSlots(JunimoNoteMenu __instance, Bundle ___currentPageBundle, bool isLeftShiftPressed = false)
+        private static void CycleThroughInputSlots(JunimoNoteMenu __instance, Bundle ___currentPageBundle, bool isLeftShiftPressed = false)
         {
             if (__instance.ingredientSlots.Count < 0)
                 return;
@@ -229,7 +229,7 @@ namespace stardew_access.Patches
             MainClass.ScreenReader.Say(toSpeak, true);
         }
 
-        private static void cycleThroughInventorySlots(JunimoNoteMenu __instance, Bundle ___currentPageBundle, bool isLeftShiftPressed = false)
+        private static void CycleThroughInventorySlots(JunimoNoteMenu __instance, Bundle ___currentPageBundle, bool isLeftShiftPressed = false)
         {
             if (__instance.inventory == null || __instance.inventory.actualInventory.Count < 0)
                 return;

--- a/stardew-access/Patches/DonationMenuPatches/FieldOfficeMenuPatch.cs
+++ b/stardew-access/Patches/DonationMenuPatches/FieldOfficeMenuPatch.cs
@@ -29,7 +29,7 @@ namespace stardew_access.Patches
                 }
                 else
                 {
-                    if (InventoryUtils.narrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y))
+                    if (InventoryUtils.NarrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y))
                         return;
 
                     for (int i = 0; i < __instance.pieceHolders.Count; i++)
@@ -58,7 +58,7 @@ namespace stardew_access.Patches
 
                         if (!MainClass.Config.DisableInventoryVerbosity && __instance.heldItem != null && __instance.pieceHolders[i].item == null)
                         {
-                            int highlight = getPieceIndexForDonationItem(__instance.heldItem.ParentSheetIndex);
+                            int highlight = GetPieceIndexForDonationItem(__instance.heldItem.ParentSheetIndex);
                             if (highlight != -1 && highlight == i)
                                 toSpeak += "Donatable ";
                         }
@@ -88,7 +88,7 @@ namespace stardew_access.Patches
             }
         }
 
-        internal static int getPieceIndexForDonationItem(int itemIndex)
+        internal static int GetPieceIndexForDonationItem(int itemIndex)
         {
             return itemIndex switch
             {

--- a/stardew-access/Patches/DonationMenuPatches/MuseumMenuPatch.cs
+++ b/stardew-access/Patches/DonationMenuPatches/MuseumMenuPatch.cs
@@ -55,9 +55,9 @@ namespace stardew_access.Patches
             {
                 int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position
 
-                narrateMuseumInventory(__instance, x, y);
+                NarrateMuseumInventory(__instance, x, y);
 
-                narratePlayerInventory(__instance, x, y);
+                NarratePlayerInventory(__instance, x, y);
             }
             catch (Exception e)
             {
@@ -65,7 +65,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static void narrateMuseumInventory(MuseumMenu __instance, int x, int y)
+        private static void NarrateMuseumInventory(MuseumMenu __instance, int x, int y)
         {
             if (__instance.heldItem == null) return;
 
@@ -80,13 +80,13 @@ namespace stardew_access.Patches
             MainClass.ScreenReader.SayWithMenuChecker(toSpeak, true);
         }
 
-        private static void narratePlayerInventory(MuseumMenu __instance, int x, int y)
+        private static void NarratePlayerInventory(MuseumMenu __instance, int x, int y)
         {
             if (__instance.heldItem != null) return;
 
-            if (narrateHoveredButtons(__instance, x, y)) return;
+            if (NarrateHoveredButtons(__instance, x, y)) return;
 
-            int hoveredItemIndex = InventoryUtils.narrateHoveredSlotAndReturnIndex(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y,
+            int hoveredItemIndex = InventoryUtils.NarrateHoveredSlotAndReturnIndex(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y,
                     handleHighlightedItem: true, highlightedItemPrefix: "Donatable ");
             if (hoveredItemIndex != -9999)
             {
@@ -94,12 +94,12 @@ namespace stardew_access.Patches
 
                 if (isPrimaryInfoKeyPressed && hoveredItemIndex >= 0 && hoveredItemIndex < __instance.inventory.actualInventory.Count && __instance.inventory.actualInventory[hoveredItemIndex] != null)
                 {
-                    manuallyDonateItem(__instance, hoveredItemIndex);
+                    ManuallyDonateItem(__instance, hoveredItemIndex);
                 }
             }
         }
 
-        private static bool narrateHoveredButtons(MuseumMenu __instance, int x, int y)
+        private static bool NarrateHoveredButtons(MuseumMenu __instance, int x, int y)
         {
             string toSpeak = "";
             bool isDropItemButton = false;
@@ -124,7 +124,7 @@ namespace stardew_access.Patches
             return true;
         }
 
-        private static void manuallyDonateItem(MuseumMenu __instance, int i)
+        private static void ManuallyDonateItem(MuseumMenu __instance, int i)
         {
             foreach (var (x, y) in donationTiles)
             {
@@ -157,13 +157,13 @@ namespace stardew_access.Patches
                     switch (pieces)
                     {
                         case 95:
-                            globalChatInfoMessage("MuseumComplete", Game1.player.farmName.Value);
+                            GlobalChatInfoMessage("MuseumComplete", Game1.player.farmName.Value);
                             break;
                         case 40:
-                            globalChatInfoMessage("Museum40", Game1.player.farmName.Value);
+                            GlobalChatInfoMessage("Museum40", Game1.player.farmName.Value);
                             break;
                         default:
-                            globalChatInfoMessage("donation", Game1.player.Name, "object:" + objectID);
+                            GlobalChatInfoMessage("donation", Game1.player.Name, "object:" + objectID);
                             break;
                     }
                     break;
@@ -173,16 +173,16 @@ namespace stardew_access.Patches
         }
 
         #region These methods are taken from the game's source code, https://github.com/veywrn/StardewValley/blob/3ff171b6e9e6839555d7881a391b624ccd820a83/StardewValley/Multiplayer.cs#L1331-L1395
-        internal static void globalChatInfoMessage(string messageKey, params string[] args)
+        internal static void GlobalChatInfoMessage(string messageKey, params string[] args)
         {
             if (Game1.IsMultiplayer || Game1.multiplayerMode != 0)
             {
-                receiveChatInfoMessage(Game1.player, messageKey, args);
-                sendChatInfoMessage(messageKey, args);
+                ReceiveChatInfoMessage(Game1.player, messageKey, args);
+                SendChatInfoMessage(messageKey, args);
             }
         }
 
-        internal static void sendChatInfoMessage(string messageKey, params string[] args)
+        internal static void SendChatInfoMessage(string messageKey, params string[] args)
         {
             if (Game1.IsClient)
             {
@@ -197,7 +197,7 @@ namespace stardew_access.Patches
             }
         }
 
-        internal static void receiveChatInfoMessage(Farmer sourceFarmer, string messageKey, string[] args)
+        internal static void ReceiveChatInfoMessage(Farmer sourceFarmer, string messageKey, string[] args)
         {
             if (Game1.chatBox != null)
             {

--- a/stardew-access/Patches/GameMenuPatches/CollectionsPagePatch.cs
+++ b/stardew-access/Patches/GameMenuPatches/CollectionsPagePatch.cs
@@ -9,7 +9,7 @@ namespace stardew_access.Patches
                 int x = StardewValley.Game1.getMousePosition().X, y = StardewValley.Game1.getMousePosition().Y;
                 if (__instance.letterviewerSubMenu != null)
                 {
-                    LetterViwerMenuPatch.narrateLetterContent(__instance.letterviewerSubMenu);
+                    LetterViwerMenuPatch.NarrateLetterContent(__instance.letterviewerSubMenu);
                 }
             }
             catch (System.Exception e)

--- a/stardew-access/Patches/GameMenuPatches/CraftingPagePatch.cs
+++ b/stardew-access/Patches/GameMenuPatches/CraftingPagePatch.cs
@@ -16,19 +16,19 @@ namespace stardew_access.Patches
             {
                 int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position
 
-                handleKeyBinds(__instance, ___currentCraftingPage);
+                HandleKeyBinds(__instance, ___currentCraftingPage);
 
-                if (narrateMenuButtons(__instance, x, y))
+                if (NarrateMenuButtons(__instance, x, y))
                 {
                     return;
                 }
 
-                if (narrateHoveredRecipe(__instance, ___currentCraftingPage, ___hoverRecipe, x, y))
+                if (NarrateHoveredRecipe(__instance, ___currentCraftingPage, ___hoverRecipe, x, y))
                 {
                     return;
                 }
 
-                InventoryUtils.narrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y);
+                InventoryUtils.NarrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y);
             }
             catch (Exception e)
             {
@@ -36,7 +36,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static void handleKeyBinds(CraftingPage __instance, int ___currentCraftingPage)
+        private static void HandleKeyBinds(CraftingPage __instance, int ___currentCraftingPage)
         {
             if (MainClass.Config.SnapToFirstSecondaryInventorySlotKey.JustPressed() && __instance.pagesOfCraftingRecipes[___currentCraftingPage].Count > 0)
             {
@@ -55,12 +55,12 @@ namespace stardew_access.Patches
             else if (MainClass.Config.CraftingMenuCycleThroughRecipiesKey.JustPressed() && !isSelectingRecipe)
             {
                 isSelectingRecipe = true;
-                CycleThroughRecipies(__instance.pagesOfCraftingRecipes, ___currentCraftingPage, __instance);
+                CycleThroughRecipes(__instance.pagesOfCraftingRecipes, ___currentCraftingPage, __instance);
                 Task.Delay(200).ContinueWith(_ => { isSelectingRecipe = false; });
             }
         }
 
-        private static bool narrateMenuButtons(CraftingPage __instance, int x, int y)
+        private static bool NarrateMenuButtons(CraftingPage __instance, int x, int y)
         {
             string? toSpeak = null;
             bool isDropItemButton = false;
@@ -93,7 +93,7 @@ namespace stardew_access.Patches
             return true;
         }
 
-        private static bool narrateHoveredRecipe(CraftingPage __instance, int ___currentCraftingPage, CraftingRecipe ___hoverRecipe, int x, int y)
+        private static bool NarrateHoveredRecipe(CraftingPage __instance, int ___currentCraftingPage, CraftingRecipe ___hoverRecipe, int x, int y)
         {
             if (___hoverRecipe == null)
             {
@@ -124,7 +124,7 @@ namespace stardew_access.Patches
             string craftable = "";
 
             description = $"Description:\n{___hoverRecipe.description}";
-            craftable = ___hoverRecipe.doesFarmerHaveIngredientsInInventory(getContainerContents(__instance._materialContainers)) ? "Craftable" : "Not Craftable";
+            craftable = ___hoverRecipe.doesFarmerHaveIngredientsInInventory(GetContainerContents(__instance._materialContainers)) ? "Craftable" : "Not Craftable";
 
             #region Crafting ingredients
             ingredients = "Ingredients:\n";
@@ -189,7 +189,7 @@ namespace stardew_access.Patches
             return true;
         }
 
-        private static void CycleThroughRecipies(List<Dictionary<ClickableTextureComponent, CraftingRecipe>> pagesOfCraftingRecipes, int ___currentCraftingPage, CraftingPage __instance)
+        private static void CycleThroughRecipes(List<Dictionary<ClickableTextureComponent, CraftingRecipe>> pagesOfCraftingRecipes, int ___currentCraftingPage, CraftingPage __instance)
         {
             currentSelectedCraftingRecipe++;
             if (currentSelectedCraftingRecipe < 0 || currentSelectedCraftingRecipe >= pagesOfCraftingRecipes[0].Count)
@@ -200,12 +200,12 @@ namespace stardew_access.Patches
 
             // Skip if recipe is not unlocked/unknown
             if (pagesOfCraftingRecipes[___currentCraftingPage].ElementAt(currentSelectedCraftingRecipe).Key.hoverText.Equals("ghosted"))
-                CycleThroughRecipies(pagesOfCraftingRecipes, ___currentCraftingPage, __instance);
+                CycleThroughRecipes(pagesOfCraftingRecipes, ___currentCraftingPage, __instance);
         }
 
         // This method is used to get the inventory items to check if the player has enough ingredients for a recipe
         // Taken from CraftingPage.cs -> 169 line
-        internal static IList<Item>? getContainerContents(List<Chest> materialContainers)
+        internal static IList<Item>? GetContainerContents(List<Chest> materialContainers)
         {
             if (materialContainers == null)
             {

--- a/stardew-access/Patches/GameMenuPatches/InventoryPagePatch.cs
+++ b/stardew-access/Patches/GameMenuPatches/InventoryPagePatch.cs
@@ -15,19 +15,19 @@ namespace stardew_access.Patches
             {
                 int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position
 
-                handleKeyBinds();
+                HandleKeyBinds();
 
-                if (narrateHoveredButton(__instance, x, y))
+                if (NarrateHoveredButton(__instance, x, y))
                 {
                     return;
                 }
 
-                if (narrateHoveredEquipmentSlot(__instance, x, y))
+                if (NarrateHoveredEquipmentSlot(__instance, x, y))
                 {
                     return;
                 }
 
-                if (InventoryUtils.narrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y, true))
+                if (InventoryUtils.NarrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y, true))
                 {
                     inventoryPageQueryKey = "";
                     return;
@@ -42,7 +42,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static void handleKeyBinds()
+        private static void HandleKeyBinds()
         {
             if (!MainClass.Config.MoneyKey.JustPressed())
                 return;
@@ -72,7 +72,7 @@ namespace stardew_access.Patches
             MainClass.ScreenReader.Say(toSpeak, true);
         }
 
-        private static bool narrateHoveredButton(InventoryPage __instance, int x, int y)
+        private static bool NarrateHoveredButton(InventoryPage __instance, int x, int y)
         {
             string? toSpeak = null;
             bool isDropItemButton = false;
@@ -114,14 +114,14 @@ namespace stardew_access.Patches
             return true;
         }
 
-        private static bool narrateHoveredEquipmentSlot(InventoryPage __instance, int mouseX, int mouseY)
+        private static bool NarrateHoveredEquipmentSlot(InventoryPage __instance, int mouseX, int mouseY)
         {
             for (int i = 0; i < __instance.equipmentIcons.Count; i++)
             {
                 if (!__instance.equipmentIcons[i].containsPoint(mouseX, mouseY))
                     continue;
 
-                string toSpeak = getNameAndDescriptionOfItem(__instance.equipmentIcons[i].name);
+                string toSpeak = GetNameAndDescriptionOfItem(__instance.equipmentIcons[i].name);
 
                 if (inventoryPageQueryKey != toSpeak)
                 {
@@ -136,7 +136,7 @@ namespace stardew_access.Patches
             return false;
         }
 
-        private static string getNameAndDescriptionOfItem(string slotName) => slotName switch
+        private static string GetNameAndDescriptionOfItem(string slotName) => slotName switch
         {
             "Hat" => (Game1.player.hat.Value != null) ? $"{Game1.player.hat.Value.DisplayName}, {Game1.player.hat.Value.getDescription()}" : "Hat slot",
             "Left Ring" => (Game1.player.leftRing.Value != null) ? $"{Game1.player.leftRing.Value.DisplayName}, {Game1.player.leftRing.Value.getDescription()}" : "Left Ring slot",

--- a/stardew-access/Patches/GameMenuPatches/SocialPagePatch.cs
+++ b/stardew-access/Patches/GameMenuPatches/SocialPagePatch.cs
@@ -17,11 +17,11 @@ namespace stardew_access.Patches
                     if (i >= ___sprites.Count)
                         continue;
 
-                    if (__instance.names[i] is string && narrateNPCDetails(__instance, i, ___kidsNames, x, y))
+                    if (__instance.names[i] is string && NarrateNPCDetails(__instance, i, ___kidsNames, x, y))
                     {
                         return;
                     }
-                    else if (__instance.names[i] is long && narrateFarmerDetails(__instance, i, ___sprites, x, y))
+                    else if (__instance.names[i] is long && NarrateFarmerDetails(__instance, i, ___sprites, x, y))
                     {
                         return;
                     }
@@ -33,7 +33,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static bool narrateNPCDetails(SocialPage __instance, int i, List<string> ___kidsNames, int x, int y)
+        private static bool NarrateNPCDetails(SocialPage __instance, int i, List<string> ___kidsNames, int x, int y)
         {
             if (!__instance.characterSlots[i].bounds.Contains(x, y))
                 return false;
@@ -114,7 +114,7 @@ namespace stardew_access.Patches
             return true;
         }
 
-        private static bool narrateFarmerDetails(SocialPage __instance, int i, List<ClickableTextureComponent> ___sprites, int x, int y)
+        private static bool NarrateFarmerDetails(SocialPage __instance, int i, List<ClickableTextureComponent> ___sprites, int x, int y)
         {
             long farmerID = (long)__instance.names[i];
             Farmer farmer = Game1.getFarmerMaybeOffline(farmerID);

--- a/stardew-access/Patches/MenuWithInventoryPatches/ForgeMenuPatch.cs
+++ b/stardew-access/Patches/MenuWithInventoryPatches/ForgeMenuPatch.cs
@@ -14,9 +14,9 @@ namespace stardew_access.Patches
             {
                 int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position
 
-                if (narrateHoveredButton(__instance, x, y)) return;
+                if (NarrateHoveredButton(__instance, x, y)) return;
 
-                if (InventoryUtils.narrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y))
+                if (InventoryUtils.NarrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y))
                 {
                     Cleanup();
                 }
@@ -28,7 +28,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static bool narrateHoveredButton(ForgeMenu __instance, int x, int y)
+        private static bool NarrateHoveredButton(ForgeMenu __instance, int x, int y)
         {
             string toSpeak = "";
             bool isDropItemButton = false;

--- a/stardew-access/Patches/MenuWithInventoryPatches/GeodeMenuPatch.cs
+++ b/stardew-access/Patches/MenuWithInventoryPatches/GeodeMenuPatch.cs
@@ -14,10 +14,10 @@ namespace stardew_access.Patches
             {
                 int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position
 
-                if (narrateRecievedTreasure(__instance)) return;
-                if (narrateHoveredButton(__instance, x, y)) return;
+                if (NarrateRecievedTreasure(__instance)) return;
+                if (NarrateHoveredButton(__instance, x, y)) return;
 
-                if (InventoryUtils.narrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y))
+                if (InventoryUtils.NarrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y))
                     geodeMenuQueryKey = "";
             }
             catch (Exception e)
@@ -26,7 +26,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static bool narrateRecievedTreasure(GeodeMenu __instance)
+        private static bool NarrateRecievedTreasure(GeodeMenu __instance)
         {
             // Narrates the treasure recieved on breaking the geode
             if (__instance.geodeTreasure == null) return false;
@@ -44,7 +44,7 @@ namespace stardew_access.Patches
             return true;
         }
 
-        private static bool narrateHoveredButton(GeodeMenu __instance, int x, int y)
+        private static bool NarrateHoveredButton(GeodeMenu __instance, int x, int y)
         {
             string toSpeak = "";
             bool isDropItemButton = false;

--- a/stardew-access/Patches/MenuWithInventoryPatches/ItemGrabMenuPatch.cs
+++ b/stardew-access/Patches/MenuWithInventoryPatches/ItemGrabMenuPatch.cs
@@ -26,24 +26,24 @@ namespace stardew_access.Patches
                     __instance.inventory.inventory[0].snapMouseCursorToCenter();
                 }
 
-                if (narrateHoveredButton(__instance, x, y))
+                if (NarrateHoveredButton(__instance, x, y))
                 {
                     InventoryUtils.Cleanup();
                     return;
                 }
-                if (narrateLastShippedItem(__instance, x, y))
+                if (NarrateLastShippedItem(__instance, x, y))
                 {
                     InventoryUtils.Cleanup();
                     return;
                 }
 
-                if (InventoryUtils.narrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y, true))
+                if (InventoryUtils.NarrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y, true))
                 {
                     itemGrabMenuQueryKey = "";
                     return;
                 }
 
-                if (InventoryUtils.narrateHoveredSlot(__instance.ItemsToGrabMenu, __instance.ItemsToGrabMenu.inventory, __instance.ItemsToGrabMenu.actualInventory, x, y, true))
+                if (InventoryUtils.NarrateHoveredSlot(__instance.ItemsToGrabMenu, __instance.ItemsToGrabMenu.inventory, __instance.ItemsToGrabMenu.actualInventory, x, y, true))
                 {
                     itemGrabMenuQueryKey = "";
                     return;
@@ -55,7 +55,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static bool narrateHoveredButton(ItemGrabMenu __instance, int x, int y)
+        private static bool NarrateHoveredButton(ItemGrabMenu __instance, int x, int y)
         {
             string toSpeak = "";
             bool isDropItemButton = false;
@@ -128,7 +128,7 @@ namespace stardew_access.Patches
             return true;
         }
 
-        private static bool narrateLastShippedItem(ItemGrabMenu __instance, int x, int y)
+        private static bool NarrateLastShippedItem(ItemGrabMenu __instance, int x, int y)
         {
             if (!__instance.shippingBin || Game1.getFarm().lastItemShipped == null || !__instance.lastShippedHolder.containsPoint(x, y))
                 return false;
@@ -149,7 +149,7 @@ namespace stardew_access.Patches
         }
 
         // TODO Add color names
-        private static string getChestColorName(int i)
+        private static string GetChestColorName(int i)
         {
             string toReturn = "";
             switch (i)

--- a/stardew-access/Patches/MenuWithInventoryPatches/ShopMenuPatch.cs
+++ b/stardew-access/Patches/MenuWithInventoryPatches/ShopMenuPatch.cs
@@ -26,15 +26,15 @@ namespace stardew_access.Patches
                     __instance.setCurrentlySnappedComponentTo(__instance.inventory.inventory[0].myID);
                 }
 
-                if (narrateHoveredButton(__instance, x, y)) return;
+                if (NarrateHoveredButton(__instance, x, y)) return;
 
-                if (InventoryUtils.narrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y, hoverPrice: __instance.hoverPrice))
+                if (InventoryUtils.NarrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y, hoverPrice: __instance.hoverPrice))
                 {
                     shopMenuQueryKey = "";
                     return;
                 }
 
-                narrateHoveredSellingItem(__instance);
+                NarrateHoveredSellingItem(__instance);
             }
             catch (Exception e)
             {
@@ -42,7 +42,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static bool narrateHoveredButton(ShopMenu __instance, int x, int y)
+        private static bool NarrateHoveredButton(ShopMenu __instance, int x, int y)
         {
             string toSpeak = "";
             bool isDropItemButton = false;
@@ -75,7 +75,7 @@ namespace stardew_access.Patches
             return true;
         }
 
-        private static void narrateHoveredSellingItem(ShopMenu __instance)
+        private static void NarrateHoveredSellingItem(ShopMenu __instance)
         {
             if (__instance.hoveredItem == null) return;
 

--- a/stardew-access/Patches/MenuWithInventoryPatches/TailoringMenuPatch.cs
+++ b/stardew-access/Patches/MenuWithInventoryPatches/TailoringMenuPatch.cs
@@ -14,7 +14,7 @@ namespace stardew_access.Patches
             {
                 int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position
 
-                if (InventoryUtils.narrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y))
+                if (InventoryUtils.NarrateHoveredSlot(__instance.inventory, __instance.inventory.inventory, __instance.inventory.actualInventory, x, y))
                     return;
 
 
@@ -25,7 +25,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static bool narrateHoveredButton(TailoringMenu __instance, int x, int y)
+        private static bool NarrateHoveredButton(TailoringMenu __instance, int x, int y)
         {
             string toSpeak = "";
             bool isDropItemButton = false;

--- a/stardew-access/Patches/MiniGamesPatches/FishingMiniGamePatch.cs
+++ b/stardew-access/Patches/MiniGamesPatches/FishingMiniGamePatch.cs
@@ -14,7 +14,7 @@ namespace stardew_access.Patches
             {
                 if (___distanceFromCatching <= 0f)
                 {
-                    cleanup();
+                    Cleanup();
                     return;
                 }
 
@@ -36,11 +36,11 @@ namespace stardew_access.Patches
 
                 if (Game1.soundBank == null) return;
 
-                handleProgressBarSound(___distanceFromCatching);
+                HandleProgressBarSound(___distanceFromCatching);
 
-                handleBobberBarCollisionSound(___bobberBarPos, ___bobberBarSpeed, ___bobberBarHeight);
+                HandleBobberBarCollisionSound(___bobberBarPos, ___bobberBarSpeed, ___bobberBarHeight);
 
-                handleBobberTargetSound(___bobberPosition, ___bobberBarPos, ___bobberInBar, ___bobberBarHeight);
+                HandleBobberTargetSound(___bobberPosition, ___bobberBarPos, ___bobberInBar, ___bobberBarHeight);
             }
             catch (System.Exception e)
             {
@@ -48,7 +48,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static void handleBobberTargetSound(float ___bobberPosition, float ___bobberBarPos, bool ___bobberInBar, int ___bobberBarHeight)
+        private static void HandleBobberTargetSound(float ___bobberPosition, float ___bobberBarPos, bool ___bobberInBar, int ___bobberBarHeight)
         {
             bobberSound ??= Game1.soundBank.GetCue("SinWave");
 
@@ -90,7 +90,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static void handleProgressBarSound(float ___distanceFromCatching)
+        private static void HandleProgressBarSound(float ___distanceFromCatching)
         {
             if (___distanceFromCatching > previousDistanceFromCatching)
             {
@@ -136,7 +136,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static void handleBobberBarCollisionSound(float ___bobberBarPos, float ___bobberBarSpeed, int ___bobberBarHeight)
+        private static void HandleBobberBarCollisionSound(float ___bobberBarPos, float ___bobberBarSpeed, int ___bobberBarHeight)
         {
             float estimatedBobberBarPos = ___bobberBarPos + ___bobberBarSpeed;
             if (estimatedBobberBarPos + (float)___bobberBarHeight > 568f)
@@ -151,7 +151,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static void cleanup()
+        private static void Cleanup()
         {
             if (bobberSound != null && bobberSound.IsPlaying)
             {

--- a/stardew-access/Patches/MiniGamesPatches/GrandpaStoryPatch.cs
+++ b/stardew-access/Patches/MiniGamesPatches/GrandpaStoryPatch.cs
@@ -17,7 +17,7 @@ namespace stardew_access.Patches
 
                 if (___letterView != null)
                 {
-                    LetterViwerMenuPatch.narrateLetterContent(___letterView);
+                    LetterViwerMenuPatch.NarrateLetterContent(___letterView);
                 }
 
                 if (MainClass.ModHelper == null)
@@ -50,13 +50,13 @@ namespace stardew_access.Patches
                 {
                     if (___grandpaSpeechTimer > 3000)
                     {
-                        if (clickableGrandpaLetterRect(___parallaxPan, ___grandpaSpeechTimer).Contains(x, y))
+                        if (ClickableGrandpaLetterRect(___parallaxPan, ___grandpaSpeechTimer).Contains(x, y))
                         {
                             toSpeak = MainClass.ModHelper.Translation.Get("grandpastory.letteropen");
                         }
                         else if (___letterView == null)
                         {
-                            Point pos = clickableGrandpaLetterRect(___parallaxPan, ___grandpaSpeechTimer).Center;
+                            Point pos = ClickableGrandpaLetterRect(___parallaxPan, ___grandpaSpeechTimer).Center;
                             Game1.setMousePositionRaw((int)((float)pos.X * Game1.options.zoomLevel), (int)((float)pos.Y * Game1.options.zoomLevel));
                             return;
                         }
@@ -80,7 +80,7 @@ namespace stardew_access.Patches
         }
 
         // This method is taken from the game's source code
-        private static Rectangle clickableGrandpaLetterRect(int ___parallaxPan, int ___grandpaSpeechTimer)
+        private static Rectangle ClickableGrandpaLetterRect(int ___parallaxPan, int ___grandpaSpeechTimer)
         {
             return new Rectangle((int)Utility.getTopLeftPositionForCenteringOnScreen(Game1.viewport, 1294, 730).X + (286 - ___parallaxPan) * 4, (int)Utility.getTopLeftPositionForCenteringOnScreen(Game1.viewport, 1294, 730).Y + 218 + Math.Max(0, Math.Min(60, (___grandpaSpeechTimer - 5000) / 8)), 524, 344);
         }

--- a/stardew-access/Patches/MiscPatches/DialogueBoxPatch.cs
+++ b/stardew-access/Patches/MiscPatches/DialogueBoxPatch.cs
@@ -14,9 +14,9 @@ namespace stardew_access.Patches
             {
                 if (__instance.transitioning) return;
 
-                if (narrateCharacterDialogue(__instance)) return;
-                if (narrateQuestionDialogue(__instance)) return;
-                narrateBasicDialogue(__instance.getCurrentString());
+                if (NarrateCharacterDialogue(__instance)) return;
+                if (NarrateQuestionDialogue(__instance)) return;
+                NarrateBasicDialogue(__instance.getCurrentString());
             }
             catch (Exception e)
             {
@@ -30,7 +30,7 @@ namespace stardew_access.Patches
             Cleanup();
         }
 
-        private static bool narrateCharacterDialogue(DialogueBox __instance)
+        private static bool NarrateCharacterDialogue(DialogueBox __instance)
         {
             if (__instance.characterDialogue == null) return false;
 
@@ -45,7 +45,7 @@ namespace stardew_access.Patches
 
             if (hasResponses)
             {
-                responseText = getCurrentResponseText(__instance);
+                responseText = GetCurrentResponseText(__instance);
 
                 CheckAndSpeak(isDialogueAppearingFirstTime ? $"{dialogueText} \n\t {responseText}" : responseText, responseText);
                 if (isDialogueAppearingFirstTime) isDialogueAppearingFirstTime = false;
@@ -58,7 +58,7 @@ namespace stardew_access.Patches
             return true;
         }
 
-        private static bool narrateQuestionDialogue(DialogueBox __instance)
+        private static bool NarrateQuestionDialogue(DialogueBox __instance)
         {
             if (!__instance.isQuestion) return false;
 
@@ -72,7 +72,7 @@ namespace stardew_access.Patches
 
             questionText = __instance.getCurrentString();
 
-            responseText = getCurrentResponseText(__instance);
+            responseText = GetCurrentResponseText(__instance);
 
             CheckAndSpeak(isDialogueAppearingFirstTime ? $"{questionText} \n\t {responseText}" : responseText, responseText);
             if (isDialogueAppearingFirstTime) isDialogueAppearingFirstTime = false;
@@ -80,14 +80,14 @@ namespace stardew_access.Patches
             return true;
         }
 
-        private static void narrateBasicDialogue(string dialogue)
+        private static void NarrateBasicDialogue(string dialogue)
         {
             // Basic dialogues like `No mails in the mail box`
             if (Game1.activeClickableMenu is not DialogueBox) return;
             CheckAndSpeak(dialogue);
         }
 
-        private static string getCurrentResponseText(DialogueBox __instance)
+        private static string GetCurrentResponseText(DialogueBox __instance)
         {
             List<Response> responses = __instance.responses;
             if (__instance.selectedResponse >= 0 && __instance.selectedResponse < responses.Count)

--- a/stardew-access/Patches/MiscPatches/IClickableMenuPatch.cs
+++ b/stardew-access/Patches/MiscPatches/IClickableMenuPatch.cs
@@ -266,7 +266,7 @@ namespace stardew_access.Patches
                     JojaCDMenuPatch.Cleanup();
                     break;
                 case QuestLog:
-                    QuestLogPatch.Cleaup();
+                    QuestLogPatch.Cleanup();
                     break;
                 case TailoringMenu:
                     TailoringMenuPatch.Cleanup();

--- a/stardew-access/Patches/MiscPatches/TextBoxPatch.cs
+++ b/stardew-access/Patches/MiscPatches/TextBoxPatch.cs
@@ -4,7 +4,7 @@ namespace stardew_access.Patches
     {
         internal static string textBoxQuery = "";
         internal static string activeTextBoxes = "";
-        internal static bool isAnyTextBoxActive => activeTextBoxes != "";
+        internal static bool IsAnyTextBoxActive => activeTextBoxes != "";
 
         internal static void DrawPatch(StardewValley.Menus.TextBox __instance)
         {

--- a/stardew-access/Patches/OtherMenuPatches/AnimalQueryMenuPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/AnimalQueryMenuPatch.cs
@@ -25,7 +25,7 @@ namespace stardew_access.Patches
         {
             try
             {
-                if (TextBoxPatch.isAnyTextBoxActive)
+                if (TextBoxPatch.IsAnyTextBoxActive)
                     return;
 
                 int x = Game1.getMouseX(true),
@@ -37,9 +37,9 @@ namespace stardew_access.Patches
 
                 loveLevel = ___loveLevel;
 
-                narrateAnimalDetailsOnKeyPress(___animal, ___parentName);
+                NarrateAnimalDetailsOnKeyPress(___animal, ___parentName);
 
-                narrateHoveredButton(__instance, ___animal, ___confirmingSell, x, y);
+                NarrateHoveredButton(__instance, ___animal, ___confirmingSell, x, y);
             }
             catch (System.Exception e)
             {
@@ -49,7 +49,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static void narrateAnimalDetailsOnKeyPress( FarmAnimal ___animal, string ___parentName)
+        private static void NarrateAnimalDetailsOnKeyPress( FarmAnimal ___animal, string ___parentName)
         {
             bool isPrimaryInfoKeyPressed = MainClass.Config.PrimaryInfoKey.JustPressed();
             if (!isPrimaryInfoKeyPressed | isNarratingAnimalInfo)
@@ -94,7 +94,7 @@ namespace stardew_access.Patches
             MainClass.ScreenReader.Say(toSpeak, true);
         }
 
-        private static void narrateHoveredButton(
+        private static void NarrateHoveredButton(
             AnimalQueryMenu __instance,
             FarmAnimal ___animal,
             bool ___confirmingSell,

--- a/stardew-access/Patches/OtherMenuPatches/AnimalQueryMenuPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/AnimalQueryMenuPatch.cs
@@ -80,11 +80,11 @@ namespace stardew_access.Patches
 
             string toSpeak = Translator.Instance.Translate( "animal_query_menu-animal_info",
                 new {
-                    name = name,
-                    type = type,
+                    name,
+                    type,
                     is_baby = ___animal.isBaby() ? 1 : 0,
                     heart_count = heartCount,
-                    age = age,
+                    age,
                     parent_name = parent
                 }
             );

--- a/stardew-access/Patches/OtherMenuPatches/CarpenterMenuPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/CarpenterMenuPatch.cs
@@ -35,7 +35,7 @@ namespace stardew_access.Patches
 
                     int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position
                     bool isPrimaryInfoKeyPressed = MainClass.Config.PrimaryInfoKey.JustPressed();
-                    string blueprintInfo = getCurrentBlueprintInfo(currentBlueprint, ___price, ___ingredients);
+                    string blueprintInfo = GetCurrentBlueprintInfo(currentBlueprint, ___price, ___ingredients);
 
                     if (isPrimaryInfoKeyPressed && !isSayingBlueprintInfo)
                     {
@@ -48,7 +48,7 @@ namespace stardew_access.Patches
                     }
                     else
                     {
-                        narrateHoveredButton(__instance, ___blueprints, ___currentBlueprintIndex, x, y);
+                        NarrateHoveredButton(__instance, ___blueprints, ___currentBlueprintIndex, x, y);
                     }
                 }
                 else
@@ -71,7 +71,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static string getCurrentBlueprintInfo(BluePrint currentBlueprint, int ___price, List<Item> ___ingredients)
+        private static string GetCurrentBlueprintInfo(BluePrint currentBlueprint, int ___price, List<Item> ___ingredients)
         {
             string ingredients = "";
             string name = currentBlueprint.displayName;
@@ -117,7 +117,7 @@ namespace stardew_access.Patches
             isSayingBlueprintInfo = false;
         }
 
-        private static void narrateHoveredButton(CarpenterMenu __instance, List<BluePrint> ___blueprints, int ___currentBlueprintIndex, int x, int y)
+        private static void NarrateHoveredButton(CarpenterMenu __instance, List<BluePrint> ___blueprints, int ___currentBlueprintIndex, int x, int y)
         {
             string toSpeak = "";
             if (__instance.backButton != null && __instance.backButton.containsPoint(x, y))

--- a/stardew-access/Patches/OtherMenuPatches/LetterViewerMenuPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/LetterViewerMenuPatch.cs
@@ -14,7 +14,7 @@ namespace stardew_access.Patches
                 if (!__instance.IsActive())
                     return;
 
-                narrateLetterContent(__instance);
+                NarrateLetterContent(__instance);
             }
             catch (Exception e)
             {
@@ -22,7 +22,7 @@ namespace stardew_access.Patches
             }
         }
 
-        internal static void narrateLetterContent(LetterViewerMenu __instance)
+        internal static void NarrateLetterContent(LetterViewerMenu __instance)
         {
             int x = Game1.getMousePosition().X, y = Game1.getMousePosition().Y;
             #region Texts in the letter

--- a/stardew-access/Patches/OtherMenuPatches/NamingMenuPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/NamingMenuPatch.cs
@@ -17,7 +17,7 @@ namespace stardew_access.Patches
                     ___textBox.Selected = false;
                 }
 
-                if (TextBoxPatch.isAnyTextBoxActive) return;
+                if (TextBoxPatch.IsAnyTextBoxActive) return;
 
                 string toSpeak = "";
                 int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position

--- a/stardew-access/Patches/OtherMenuPatches/PurchaseAnimalsMenuPatch.cs
+++ b/stardew-access/Patches/OtherMenuPatches/PurchaseAnimalsMenuPatch.cs
@@ -15,7 +15,7 @@ namespace stardew_access.Patches
         {
             try
             {
-                if (TextBoxPatch.isAnyTextBoxActive) return;
+                if (TextBoxPatch.IsAnyTextBoxActive) return;
 
                 int x = Game1.getMouseX(true), y = Game1.getMouseY(true); // Mouse x and y position
                 purchaseAnimalsMenu = __instance;
@@ -24,7 +24,7 @@ namespace stardew_access.Patches
 
                 if (___onFarm && ___namingAnimal)
                 {
-                    narrateNamingMenu(__instance, ___textBox, x, y);
+                    NarrateNamingMenu(__instance, ___textBox, x, y);
                 }
                 else if (___onFarm && !___namingAnimal)
                 {
@@ -33,7 +33,7 @@ namespace stardew_access.Patches
                 else if (!___onFarm && !___namingAnimal)
                 {
                     firstTimeInNamingMenu = true;
-                    narratePurchasingMenu(__instance);
+                    NarratePurchasingMenu(__instance);
                 }
             }
             catch (Exception e)
@@ -42,7 +42,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static void narrateNamingMenu(PurchaseAnimalsMenu __instance, TextBox ___textBox, int x, int y)
+        private static void NarrateNamingMenu(PurchaseAnimalsMenu __instance, TextBox ___textBox, int x, int y)
         {
             string toSpeak = "";
             if (__instance.okButton != null && __instance.okButton.containsPoint(x, y))
@@ -78,7 +78,7 @@ namespace stardew_access.Patches
             MainClass.ScreenReader.Say(toSpeak, true);
         }
 
-        private static void narratePurchasingMenu(PurchaseAnimalsMenu __instance)
+        private static void NarratePurchasingMenu(PurchaseAnimalsMenu __instance)
         {
             if (__instance.hovered == null)
                 return;

--- a/stardew-access/Patches/QuestPatches/BillboardPatch.cs
+++ b/stardew-access/Patches/QuestPatches/BillboardPatch.cs
@@ -14,11 +14,11 @@ namespace stardew_access.Patches
             {
                 if (___dailyQuestBoard)
                 {
-                    narrateDailyQuestBoard(__instance);
+                    NarrateDailyQuestBoard(__instance);
                 }
                 else
                 {
-                    narrateCalendar(__instance);
+                    NarrateCalendar(__instance);
                 }
             }
             catch (Exception e)
@@ -27,7 +27,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static void narrateCalendar(Billboard __instance)
+        private static void NarrateCalendar(Billboard __instance)
         {
             for (int i = 0; i < __instance.calendarDays.Count; i++)
             {
@@ -60,7 +60,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static void narrateDailyQuestBoard(Billboard __instance)
+        private static void NarrateDailyQuestBoard(Billboard __instance)
         {
             if (Game1.questOfTheDay == null || Game1.questOfTheDay.currentObjective == null || Game1.questOfTheDay.currentObjective.Length == 0)
             {

--- a/stardew-access/Patches/QuestPatches/QuestLogPatch.cs
+++ b/stardew-access/Patches/QuestPatches/QuestLogPatch.cs
@@ -19,11 +19,11 @@ namespace stardew_access.Patches
 
                 if (___questPage == -1)
                 {
-                    narrateQuestList(__instance, ___pages, ___currentPage, x, y);
+                    NarrateQuestList(__instance, ___pages, ___currentPage, x, y);
                 }
                 else
                 {
-                    narrateIndividualQuest(__instance, ___currentPage, ____shownQuest, ____objectiveText, x, y);
+                    NarrateIndividualQuest(__instance, ___currentPage, ____shownQuest, ____objectiveText, x, y);
                 }
             }
             catch (Exception e)
@@ -32,7 +32,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static void narrateQuestList(QuestLog __instance, List<List<IQuest>> ___pages, int ___currentPage, int x, int y)
+        private static void NarrateQuestList(QuestLog __instance, List<List<IQuest>> ___pages, int ___currentPage, int x, int y)
         {
             string toSpeak = "";
 
@@ -73,7 +73,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static void narrateIndividualQuest(QuestLog __instance, int ___currentPage, IQuest ____shownQuest, List<string> ____objectiveText, int x, int y)
+        private static void NarrateIndividualQuest(QuestLog __instance, int ___currentPage, IQuest ____shownQuest, List<string> ____objectiveText, int x, int y)
         {
             bool isPrimaryInfoKeyPressed = MainClass.Config.PrimaryInfoKey.JustPressed();
             bool containsReward = __instance.HasReward() || __instance.HasMoneyReward();
@@ -154,7 +154,7 @@ namespace stardew_access.Patches
             }
         }
 
-        internal static void Cleaup()
+        internal static void Cleanup()
         {
             questLogQuery = "";
             isNarratingQuestInfo = false;

--- a/stardew-access/Patches/QuestPatches/SpecialOrdersBoardPatch.cs
+++ b/stardew-access/Patches/QuestPatches/SpecialOrdersBoardPatch.cs
@@ -15,7 +15,7 @@ namespace stardew_access.Patches
 
                 if (__instance.acceptLeftQuestButton.visible && __instance.acceptLeftQuestButton.containsPoint(x, y))
                 {
-                    string toSpeak = getSpecialOrderDetails(__instance.leftOrder);
+                    string toSpeak = GetSpecialOrderDetails(__instance.leftOrder);
 
                     toSpeak = $"Left Quest:\n\t{toSpeak}\n\tPress left click to accept this quest.";
 
@@ -25,7 +25,7 @@ namespace stardew_access.Patches
 
                 if (__instance.acceptRightQuestButton.visible && __instance.acceptRightQuestButton.containsPoint(x, y))
                 {
-                    string toSpeak = getSpecialOrderDetails(__instance.rightOrder);
+                    string toSpeak = GetSpecialOrderDetails(__instance.rightOrder);
 
                     toSpeak = $"Right Quest:\n\t{toSpeak}\n\tPress left click to accept this quest.";
 
@@ -39,7 +39,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static string getSpecialOrderDetails(SpecialOrder order)
+        private static string GetSpecialOrderDetails(SpecialOrder order)
         {
             int daysLeft = order.GetDaysLeft();
             string description = order.GetDescription();

--- a/stardew-access/Patches/TitleMenuPatches/CharacterCustomizationMenuPatches.cs
+++ b/stardew-access/Patches/TitleMenuPatches/CharacterCustomizationMenuPatches.cs
@@ -32,7 +32,7 @@ namespace stardew_access.Patches
         private static bool characterDesignToggle = false;
         private static bool characterDesignToggleShouldSpeak = true;
         private static ClickableComponent? currentComponent = null;
-        private static Dictionary<string, Dictionary<int, string>> descriptions
+        private static Dictionary<string, Dictionary<int, string>> Descriptions
         {
             get
             {
@@ -77,7 +77,7 @@ namespace stardew_access.Patches
         {
             try
             {
-                if (TextBoxPatch.isAnyTextBoxActive) return;
+                if (TextBoxPatch.IsAnyTextBoxActive) return;
 
                 bool isEscPressed = Game1.input.GetKeyboardState().IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Escape); // For escaping/unselecting from the animal name text box
                 string toSpeak = "";
@@ -148,7 +148,7 @@ namespace stardew_access.Patches
                     toSpeak = $"Character design controls {displayState}. \n {toSpeak}";
                 }
 
-                changesToSpeak = getChangesToSpeak(__instance);
+                changesToSpeak = GetChangesToSpeak(__instance);
                 if (changesToSpeak != "")
                     toSpeak = $"{toSpeak} \n {changesToSpeak}";
 
@@ -164,7 +164,7 @@ namespace stardew_access.Patches
             }
         }
 
-        private static string getChangesToSpeak(CharacterCustomization __instance)
+        private static string GetChangesToSpeak(CharacterCustomization __instance)
         {
             string toSpeak = "";
             string currentPet = GetCurrentPet();
@@ -547,7 +547,7 @@ namespace stardew_access.Patches
             {
                 for (int i = 0; i < __instance.farmTypeButtons.Count; i++)
                 {
-                    buttons.Add(__instance.farmTypeButtons[i], ((i == Game1.whichFarm) ? "Selected " : "") + getFarmHoverText(__instance.farmTypeButtons[i]));
+                    buttons.Add(__instance.farmTypeButtons[i], ((i == Game1.whichFarm) ? "Selected " : "") + GetFarmHoverText(__instance.farmTypeButtons[i]));
                 }
             }
 
@@ -625,7 +625,7 @@ namespace stardew_access.Patches
             return toSpeak.Trim();
         }
 
-        private static string getFarmHoverText(ClickableTextureComponent farm)
+        private static string GetFarmHoverText(ClickableTextureComponent farm)
         {
             string hoverTitle = " ", hoverText = " ";
             if (!farm.name.Contains("Gray"))
@@ -652,7 +652,7 @@ namespace stardew_access.Patches
             return $"{hoverTitle}: {hoverText}";
         }
 
-        private static SliderBar? getCurrentSliderBar(int id, CharacterCustomization __instance)
+        private static SliderBar? GetCurrentSliderBar(int id, CharacterCustomization __instance)
         {
             if (id >= 522 && id <= 530)
             {
@@ -691,7 +691,7 @@ namespace stardew_access.Patches
         {
             if (currentComponent != null && currentComponent.myID >= 522 && currentComponent.myID <= 530)
             {
-                SliderBar sb = getCurrentSliderBar(currentComponent.myID, __instance)!;
+                SliderBar sb = GetCurrentSliderBar(currentComponent.myID, __instance)!;
                 if (sb != null)
                 {
                     double step = ((double)sb.bounds.Width / 100d); // size of 1% change in slider value
@@ -725,7 +725,7 @@ namespace stardew_access.Patches
                 if (!lessInfo)
                 {
                     string petType = Game1.player.catPerson ? "Cat" : "Dog";
-                    if (descriptions.TryGetValue(petType, out var innerDict) && innerDict.TryGetValue(whichPetBreed, out var description))
+                    if (Descriptions.TryGetValue(petType, out var innerDict) && innerDict.TryGetValue(whichPetBreed, out var description))
                     {
                         return description;
                     }
@@ -748,7 +748,7 @@ namespace stardew_access.Patches
 
                 if (!lessInfo)
                 {
-                    if (descriptions.TryGetValue(componentName, out var innerDict))
+                    if (Descriptions.TryGetValue(componentName, out var innerDict))
                     {
                         if (innerDict.TryGetValue(index, out var description))
                         {
@@ -793,26 +793,26 @@ namespace stardew_access.Patches
             return GetCurrentColorAttributeValue("Eye color", 522, 524, () => GetNearestColorName(Game1.player.newEyeColor.R, Game1.player.newEyeColor.G, Game1.player.newEyeColor.B));
         }
 
-        private static string GetCurrentEyeColorHue(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Hue", 522, 524, () => (getCurrentSliderBar(522, __instance)!.value!.ToString()));
-        private static string GetCurrentEyeColorSaturation(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Saturation", 522, 524, () => (getCurrentSliderBar(523, __instance)!.value!.ToString()));
-        private static string GetCurrentEyeColorValue(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Value", 522, 524, () => (getCurrentSliderBar(524, __instance)!.value!.ToString()));
+        private static string GetCurrentEyeColorHue(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Hue", 522, 524, () => (GetCurrentSliderBar(522, __instance)!.value!.ToString()));
+        private static string GetCurrentEyeColorSaturation(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Saturation", 522, 524, () => (GetCurrentSliderBar(523, __instance)!.value!.ToString()));
+        private static string GetCurrentEyeColorValue(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Value", 522, 524, () => (GetCurrentSliderBar(524, __instance)!.value!.ToString()));
 
         private static string GetCurrentHairColor()
         {
             return GetCurrentColorAttributeValue("Hair color", 525, 527, () => GetNearestColorName(Game1.player.hairstyleColor.R, Game1.player.hairstyleColor.G, Game1.player.hairstyleColor.B));
         }
 
-        private static string GetCurrentHairColorHue(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Hue", 525, 527, () => (getCurrentSliderBar(525, __instance)!.value!.ToString()));
-        private static string GetCurrentHairColorSaturation(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Saturation", 525, 527, () => (getCurrentSliderBar(526, __instance)!.value!.ToString()));
-        private static string GetCurrentHairColorValue(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Value", 525, 527, () => (getCurrentSliderBar(527, __instance)!.value!.ToString()));
+        private static string GetCurrentHairColorHue(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Hue", 525, 527, () => (GetCurrentSliderBar(525, __instance)!.value!.ToString()));
+        private static string GetCurrentHairColorSaturation(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Saturation", 525, 527, () => (GetCurrentSliderBar(526, __instance)!.value!.ToString()));
+        private static string GetCurrentHairColorValue(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Value", 525, 527, () => (GetCurrentSliderBar(527, __instance)!.value!.ToString()));
 
         private static string GetCurrentPantsColor()
         {
             return GetCurrentColorAttributeValue("Pants color", 528, 530, () => GetNearestColorName(Game1.player.pantsColor.R, Game1.player.pantsColor.G, Game1.player.pantsColor.B));
         }
 
-        private static string GetCurrentPantsColorHue(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Hue", 528, 530, () => (getCurrentSliderBar(528, __instance)!.value!.ToString()));
-        private static string GetCurrentPantsColorSaturation(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Saturation", 528, 530, () => (getCurrentSliderBar(529, __instance)!.value!.ToString()));
-        private static string GetCurrentPantsColorValue(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Value", 528, 530, () => (getCurrentSliderBar(530, __instance)!.value!.ToString()));
+        private static string GetCurrentPantsColorHue(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Hue", 528, 530, () => (GetCurrentSliderBar(528, __instance)!.value!.ToString()));
+        private static string GetCurrentPantsColorSaturation(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Saturation", 528, 530, () => (GetCurrentSliderBar(529, __instance)!.value!.ToString()));
+        private static string GetCurrentPantsColorValue(CharacterCustomization __instance) => GetCurrentColorAttributeValue("Value", 528, 530, () => (GetCurrentSliderBar(530, __instance)!.value!.ToString()));
     }
 }

--- a/stardew-access/Translation/Translator.cs
+++ b/stardew-access/Translation/Translator.cs
@@ -14,10 +14,7 @@ namespace stardew_access
         {
             get
             {
-                if (instance == null)
-                {
-                    instance = new Translator();
-                }
+                instance ??= new Translator();
 
                 return instance;
             }

--- a/stardew-access/Translation/Translator.cs
+++ b/stardew-access/Translation/Translator.cs
@@ -34,9 +34,9 @@ namespace stardew_access
             if (fluentApi != null)
             {
                 Fluent = fluentApi.GetLocalizationsForCurrentLocale(modManifest);
-                foreach ( var customFunction in new CustomFluentFunctions(modManifest, fluentApi).GetAll())
+                foreach ( var (mod, name, function) in new CustomFluentFunctions(modManifest, fluentApi).GetAll())
                 {
-                    fluentApi.RegisterFunction( customFunction.mod, customFunction.name, customFunction.function);
+                    fluentApi.RegisterFunction( mod, name, function);
                 }
             }
             else

--- a/stardew-access/Utils/InventoryUtils.cs
+++ b/stardew-access/Utils/InventoryUtils.cs
@@ -154,7 +154,7 @@ namespace stardew_access.Utils
         {
             if (price == -1) return "";
             
-            return Translator.Instance.Translate("item-sell_price_info", new {price = price});
+            return Translator.Instance.Translate("item-sell_price_info", new { price });
         }
 
         private static String handleHighlightedItemPrefix(bool isHighlighted, String prefix)

--- a/stardew-access/Utils/InventoryUtils.cs
+++ b/stardew-access/Utils/InventoryUtils.cs
@@ -8,11 +8,11 @@ namespace stardew_access.Utils
         internal static string hoveredItemQueryKey = "";
         internal static int prevSlotIndex = -999;
 
-        internal static bool narrateHoveredSlot(InventoryMenu inventoryMenu, List<ClickableComponent> inventory, IList<Item> actualInventory, int x, int y,
+        internal static bool NarrateHoveredSlot(InventoryMenu inventoryMenu, List<ClickableComponent> inventory, IList<Item> actualInventory, int x, int y,
                 bool? giveExtraDetails = null, int hoverPrice = -1, int extraItemToShowIndex = -1, int extraItemToShowAmount = -1,
                 bool handleHighlightedItem = false, String highlightedItemPrefix = "", String highlightedItemSuffix = "")
         {
-            if (narrateHoveredSlotAndReturnIndex(inventoryMenu, inventory, actualInventory, x, y,
+            if (NarrateHoveredSlotAndReturnIndex(inventoryMenu, inventory, actualInventory, x, y,
                 giveExtraDetails, hoverPrice, extraItemToShowIndex, extraItemToShowAmount,
                 handleHighlightedItem, highlightedItemPrefix, highlightedItemSuffix) == -999)
                 return false;
@@ -20,7 +20,7 @@ namespace stardew_access.Utils
             return true;
         }
 
-        internal static int narrateHoveredSlotAndReturnIndex(InventoryMenu inventoryMenu, List<ClickableComponent> inventory, IList<Item> actualInventory, int x, int y,
+        internal static int NarrateHoveredSlotAndReturnIndex(InventoryMenu inventoryMenu, List<ClickableComponent> inventory, IList<Item> actualInventory, int x, int y,
                 bool? giveExtraDetails = null, int hoverPrice = -1, int extraItemToShowIndex = -1, int extraItemToShowAmount = -1,
                 bool handleHighlightedItem = false, String highlightedItemPrefix = "", String highlightedItemSuffix = "")
         {
@@ -32,24 +32,24 @@ namespace stardew_access.Utils
                 if ((i + 1) > actualInventory.Count || actualInventory[i] == null)
                 {
                     // For empty slot
-                    checkAndSpeak(Translator.Instance.Translate("menu-inventory-empty_slot-name"), i);
+                    CheckAndSpeak(Translator.Instance.Translate("menu-inventory-empty_slot-name"), i);
                     prevSlotIndex = i;
                     return i;
                 }
 
                 bool isHighlighted = inventoryMenu.highlightMethod(actualInventory[i]);
 
-                string namePrefix = handleHighlightedItemPrefix(isHighlighted, highlightedItemPrefix);
-                string nameSuffix = $"{handleHighlightedItemSuffix(isHighlighted, highlightedItemSuffix)}{handleUnHighlightedItem(isHighlighted, i)}";
+                string namePrefix = HandleHighlightedItemPrefix(isHighlighted, highlightedItemPrefix);
+                string nameSuffix = $"{HandleHighlightedItemSuffix(isHighlighted, highlightedItemSuffix)}{HandleUnHighlightedItem(isHighlighted, i)}";
                 int stack = actualInventory[i].Stack;
                 string name = Translator.Instance.Translate("common-util-pluralize_name", new {item_count = stack, name = actualInventory[i].DisplayName});
                 name = $"{namePrefix}{name}{nameSuffix}";
-                string quality = getQualityFromItem(actualInventory[i]);
-                string healthNStamina = getHealthNStaminaFromItem(actualInventory[i]);
-                string buffs = getBuffsFromItem(actualInventory[i]);
+                string quality = GetQualityFromItem(actualInventory[i]);
+                string healthNStamina = GetHealthNStaminaFromItem(actualInventory[i]);
+                string buffs = GetBuffsFromItem(actualInventory[i]);
                 string description = actualInventory[i].getDescription();
-                string price = getPrice(hoverPrice);
-                string requirements = getExtraItemInfo(extraItemToShowIndex, extraItemToShowAmount);
+                string price = GetPrice(hoverPrice);
+                string requirements = GetExtraItemInfo(extraItemToShowIndex, extraItemToShowAmount);
 
                 string details;
                 string toSpeak = name;
@@ -65,7 +65,7 @@ namespace stardew_access.Utils
                 if (!string.IsNullOrEmpty(details))
                     toSpeak = $"{toSpeak}, {details}";
 
-                checkAndSpeak(toSpeak, i);
+                CheckAndSpeak(toSpeak, i);
                 prevSlotIndex = i;
                 return i;
             }
@@ -74,7 +74,7 @@ namespace stardew_access.Utils
             return -999;
         }
         
-        private static void checkAndSpeak(String toSpeak, int hoveredInventoryIndex)
+        private static void CheckAndSpeak(String toSpeak, int hoveredInventoryIndex)
         {
             if (hoveredItemQueryKey == $"{toSpeak}:{hoveredInventoryIndex}") return;
             
@@ -82,7 +82,7 @@ namespace stardew_access.Utils
             MainClass.ScreenReader.Say(toSpeak, true);
         }
 
-        private static String getQualityFromItem(Item item)
+        private static String GetQualityFromItem(Item item)
         {
             if (item is not StardewValley.Object || ((StardewValley.Object)item).Quality <= 0)
                 return "";
@@ -90,7 +90,7 @@ namespace stardew_access.Utils
             return Translator.Instance.Translate("item-quality_type", new {quality_index = ((StardewValley.Object)item).Quality});
         }
 
-        private static String getHealthNStaminaFromItem(Item item)
+        private static String GetHealthNStaminaFromItem(Item item)
         {
             if (item is not StardewValley.Object || ((StardewValley.Object)item).Edibility == -300)
                 return "";
@@ -100,7 +100,7 @@ namespace stardew_access.Utils
             return Translator.Instance.Translate("item-stamina_and_health_recovery_on_consumption", new {stamina_amount = stamina_recovery, health_amount = health_recovery});
         }
 
-        private static String getBuffsFromItem(Item item)
+        private static String GetBuffsFromItem(Item item)
         {
             if (item == null) return "";
             if (item is not StardewValley.Object) return "";
@@ -134,7 +134,7 @@ namespace stardew_access.Utils
             return toReturn;
         }
 
-        private static String getExtraItemInfo(int itemIndex, int itemAmount)
+        private static String GetExtraItemInfo(int itemIndex, int itemAmount)
         {
             if (itemIndex == -1) return "";
 
@@ -150,14 +150,14 @@ namespace stardew_access.Utils
                 return Translator.Instance.Translate("item-required_item_info", new {name = itemName});
         }
 
-        private static String getPrice(int price)
+        private static String GetPrice(int price)
         {
             if (price == -1) return "";
             
             return Translator.Instance.Translate("item-sell_price_info", new { price });
         }
 
-        private static String handleHighlightedItemPrefix(bool isHighlighted, String prefix)
+        private static String HandleHighlightedItemPrefix(bool isHighlighted, String prefix)
         {
             if (MainClass.Config.DisableInventoryVerbosity) return "";
             if (!isHighlighted) return "";
@@ -165,7 +165,7 @@ namespace stardew_access.Utils
             return prefix;
         }
 
-        private static String handleHighlightedItemSuffix(bool isHighlighted, String suffix)
+        private static String HandleHighlightedItemSuffix(bool isHighlighted, String suffix)
         {
             if (MainClass.Config.DisableInventoryVerbosity) return "";
             if (!isHighlighted) return "";
@@ -173,7 +173,7 @@ namespace stardew_access.Utils
             return suffix;
         }
 
-        private static String handleUnHighlightedItem(bool isHighlighted, int hoveredInventoryIndex)
+        private static String HandleUnHighlightedItem(bool isHighlighted, int hoveredInventoryIndex)
         {
             if (isHighlighted) return "";
             

--- a/stardew-access/Utils/TileInfo.cs
+++ b/stardew-access/Utils/TileInfo.cs
@@ -26,9 +26,9 @@ namespace stardew_access.Utils
         };
 
         ///<summary>Returns the name of the object at tile alongwith it's category's name</summary>
-        public static (string? name, string? categoryName) getNameWithCategoryNameAtTile(Vector2 tile, GameLocation? currentLocation)
+        public static (string? name, string? categoryName) GetNameWithCategoryNameAtTile(Vector2 tile, GameLocation? currentLocation)
         {
-            (string? name, CATEGORY? category) = getNameWithCategoryAtTile(tile, currentLocation);
+            (string? name, CATEGORY? category) = GetNameWithCategoryAtTile(tile, currentLocation);
 
             category ??= CATEGORY.Others;
 
@@ -39,11 +39,11 @@ namespace stardew_access.Utils
         public static string? GetNameAtTile(Vector2 tile, GameLocation? currentLocation = null)
         {
             currentLocation ??= Game1.currentLocation;
-            return getNameWithCategoryAtTile(tile, currentLocation).name;
+            return GetNameWithCategoryAtTile(tile, currentLocation).name;
         }
 
         ///<summary>Returns the name of the object at tile alongwith it's category</summary>
-        public static (string? name, CATEGORY? category) getNameWithCategoryAtTile(Vector2 tile, GameLocation? currentLocation, bool lessInfo = false)
+        public static (string? name, CATEGORY? category) GetNameWithCategoryAtTile(Vector2 tile, GameLocation? currentLocation, bool lessInfo = false)
         {
             currentLocation ??= Game1.currentLocation;
             int x = (int)tile.X;
@@ -57,7 +57,7 @@ namespace stardew_access.Utils
                 return (npc.displayName, category);
             }
 
-            string? farmAnimal = getFarmAnimalAt(currentLocation, x, y);
+            string? farmAnimal = GetFarmAnimalAt(currentLocation, x, y);
             if (farmAnimal is not null)
             {
                 return (farmAnimal, CATEGORY.FarmAnimals);
@@ -77,7 +77,7 @@ namespace stardew_access.Utils
 
             if (currentLocation.isObjectAtTile(x, y))
             {
-                (string? name, CATEGORY? category) = getObjectAtTile(currentLocation, x, y, lessInfo);
+                (string? name, CATEGORY? category) = GetObjectAtTile(currentLocation, x, y, lessInfo);
                 return (name, category);
             }
 
@@ -86,7 +86,7 @@ namespace stardew_access.Utils
                 return ("Water", CATEGORY.WaterTiles);
             }
 
-            string? resourceClump = getResourceClumpAtTile(currentLocation, x, y, lessInfo);
+            string? resourceClump = GetResourceClumpAtTile(currentLocation, x, y, lessInfo);
             if (resourceClump != null)
             {
                 return (resourceClump, CATEGORY.ResourceClumps);
@@ -94,7 +94,7 @@ namespace stardew_access.Utils
 
             if (terrainFeature.TryGetValue(tile, out var tf))
             {
-                (string? name, CATEGORY category) = getTerrainFeatureAtTile(tf);
+                (string? name, CATEGORY category) = GetTerrainFeatureAtTile(tf);
                 if (name != null)
                 {
                     return (name, category);
@@ -107,29 +107,29 @@ namespace stardew_access.Utils
                 return (bush, CATEGORY.Bush);
             }
 
-            string? door = getDoorAtTile(currentLocation, x, y);
-            string? warp = getWarpPointAtTile(currentLocation, x, y);
+            string? door = GetDoorAtTile(currentLocation, x, y);
+            string? warp = GetWarpPointAtTile(currentLocation, x, y);
             if (warp != null || door != null)
             {
                 return (warp ?? door, CATEGORY.Doors);
             }
 
-            if (isMineDownLadderAtTile(currentLocation, x, y))
+            if (IsMineDownLadderAtTile(currentLocation, x, y))
             {
                 return ("Ladder", CATEGORY.Doors);
             }
 
-            if (isShaftAtTile(currentLocation, x, y))
+            if (IsShaftAtTile(currentLocation, x, y))
             {
                 return ("Shaft", CATEGORY.Doors);
             }
 
-            if (isMineUpLadderAtTile(currentLocation, x, y))
+            if (IsMineUpLadderAtTile(currentLocation, x, y))
             {
                 return ("Up Ladder", CATEGORY.Doors);
             }
 
-            if (isElevatorAtTile(currentLocation, x, y))
+            if (IsElevatorAtTile(currentLocation, x, y))
             {
                 return ("Elevator", CATEGORY.Doors);
             }
@@ -274,9 +274,9 @@ namespace stardew_access.Utils
             // Return the result of the logical comparison directly, inlining operations
             // Check if the tile is NOT a warp point and if it collides with an object or terrain feature
             // OR if the tile has stumps in a Woods location
-            return !isWarpPointAtTile(currentLocation, x, y) &&
+            return !IsWarpPointAtTile(currentLocation, x, y) &&
                    (currentLocation.isCollidingPosition(new Rectangle(x * 64 + 1, y * 64 + 1, 62, 62), Game1.viewport, true, 0, glider: false, Game1.player, pathfinding: true) ||
-                   (currentLocation is Woods woods && getStumpsInWoods(woods, x, y, lessInfo) is not null));
+                   (currentLocation is Woods woods && GetStumpsInWoods(woods, x, y, lessInfo) is not null));
         }
 
         /// <summary>
@@ -299,7 +299,7 @@ namespace stardew_access.Utils
         /// <summary>
         /// Returns the name of the warp point at the specified tile coordinates, or null if not found.
         /// </summary>
-        public static string? getWarpPointAtTile(GameLocation currentLocation, int x, int y, bool lessInfo = false)
+        public static string? GetWarpPointAtTile(GameLocation currentLocation, int x, int y, bool lessInfo = false)
         {
             Warp? warpPoint = GetWarpAtTile(currentLocation, x, y);
 
@@ -314,7 +314,7 @@ namespace stardew_access.Utils
         /// <summary>
         /// Returns true if there's a warp point at the specified tile coordinates, or false otherwise.
         /// </summary>
-        public static bool isWarpPointAtTile(GameLocation currentLocation, int x, int y)
+        public static bool IsWarpPointAtTile(GameLocation currentLocation, int x, int y)
         {
             return GetWarpAtTile(currentLocation, x, y) != null;
         }
@@ -329,7 +329,7 @@ namespace stardew_access.Utils
         /// A string containing the farm animal's name, type, and age if a farm animal is found at the specified tile;
         /// null if no farm animal is found or if the location is not a Farm or an AnimalHouse.
         /// </returns>
-        public static string? getFarmAnimalAt(GameLocation location, int x, int y)
+        public static string? GetFarmAnimalAt(GameLocation location, int x, int y)
         {
             // Return null if the location is null or not a Farm or AnimalHouse
             if (location is null || !(location is Farm || location is AnimalHouse))
@@ -368,7 +368,7 @@ namespace stardew_access.Utils
         /// </summary>
         /// <param name="terrain">A reference to the terrain feature to be checked.</param>
         /// <returns>A tuple containing the name and category of the terrain feature at the tile.</returns>
-        public static (string? name, CATEGORY category) getTerrainFeatureAtTile(Netcode.NetRef<TerrainFeature> terrain)
+        public static (string? name, CATEGORY category) GetTerrainFeatureAtTile(Netcode.NetRef<TerrainFeature> terrain)
         {
             // Get the terrain feature from the reference
             var terrainFeature = terrain.Get();
@@ -376,7 +376,7 @@ namespace stardew_access.Utils
             // Check if the terrain feature is HoeDirt
             if (terrainFeature is HoeDirt dirt)
             {
-                return (getHoeDirtDetail(dirt), CATEGORY.Crops);
+                return (GetHoeDirtDetail(dirt), CATEGORY.Crops);
             }
             // Check if the terrain feature is a CosmeticPlant
             else if (terrainFeature is CosmeticPlant cosmeticPlant)
@@ -399,7 +399,7 @@ namespace stardew_access.Utils
             // Check if the terrain feature is a FruitTree
             else if (terrainFeature is FruitTree fruitTree)
             {
-                return (getFruitTree(fruitTree), CATEGORY.Trees);
+                return (GetFruitTree(fruitTree), CATEGORY.Trees);
             }
             // Check if the terrain feature is Grass
             else if (terrainFeature is Grass)
@@ -409,7 +409,7 @@ namespace stardew_access.Utils
             // Check if the terrain feature is a Tree
             else if (terrainFeature is Tree tree)
             {
-                return (getTree(tree), CATEGORY.Trees);
+                return (GetTree(tree), CATEGORY.Trees);
             }
 
             return (null, CATEGORY.Others);
@@ -421,7 +421,7 @@ namespace stardew_access.Utils
         /// <param name="dirt">The HoeDirt object to get details for.</param>
         /// <param name="ignoreIfEmpty">If true, the method will return an empty string for empty soil; otherwise, it will return "Soil".</param>
         /// <returns>A string representing the details of the provided HoeDirt object.</returns>
-        public static string getHoeDirtDetail(HoeDirt dirt, bool ignoreIfEmpty = false)
+        public static string GetHoeDirtDetail(HoeDirt dirt, bool ignoreIfEmpty = false)
         {
             // Use StringBuilder for efficient string manipulation
             StringBuilder detail = new();
@@ -481,7 +481,7 @@ namespace stardew_access.Utils
         /// </summary>
         /// <param name="fruitTree">The FruitTree object to get the name for.</param>
         /// <returns>The fruit tree's display name.</returns>
-        public static string getFruitTree(FruitTree fruitTree)
+        public static string GetFruitTree(FruitTree fruitTree)
         {
             int stage = fruitTree.growthStage.Value;
             int fruitIndex = fruitTree.indexOfFruit.Get();
@@ -513,7 +513,7 @@ namespace stardew_access.Utils
         /// </summary>
         /// <param name="tree">The Tree object to get the name for.</param>
         /// <returns>The tree's display name.</returns>
-        public static string getTree(Tree tree)
+        public static string GetTree(Tree tree)
         {
             int treeType = tree.treeType.Value;
             int treeStage = tree.growthStage.Value;
@@ -575,7 +575,7 @@ namespace stardew_access.Utils
         /// <param name="y">The Y coordinate of the tile.</param>
         /// <param name="lessInfo">An optional parameter to display less information, set to false by default.</param>
         /// <returns>A tuple containing the object's name and category.</returns>
-        public static (string? name, CATEGORY category) getObjectAtTile(GameLocation currentLocation, int x, int y, bool lessInfo = false)
+        public static (string? name, CATEGORY category) GetObjectAtTile(GameLocation currentLocation, int x, int y, bool lessInfo = false)
         {
             (string? name, CATEGORY category) toReturn = (null, CATEGORY.Others);
 
@@ -587,7 +587,7 @@ namespace stardew_access.Utils
             toReturn.name = obj.DisplayName;
 
             // Get object names and categories based on index
-            (string? name, CATEGORY category) correctNameAndCategory = getCorrectNameAndCategoryFromIndex(index, obj.Name);
+            (string? name, CATEGORY category) correctNameAndCategory = GetCorrectNameAndCategoryFromIndex(index, obj.Name);
 
             // Check the object type and assign the appropriate name and category
             if (obj is Chest chest)
@@ -596,7 +596,7 @@ namespace stardew_access.Utils
             }
             else if (obj is IndoorPot indoorPot)
             {
-                toReturn.name = $"{obj.DisplayName}, {getHoeDirtDetail(indoorPot.hoeDirt.Value, true)}";
+                toReturn.name = $"{obj.DisplayName}, {GetHoeDirtDetail(indoorPot.hoeDirt.Value, true)}";
             }
             else if (obj is Sign sign && sign.displayItem.Value != null)
             {
@@ -724,7 +724,7 @@ namespace stardew_access.Utils
         /// <param name="index">The object's index value.</param>
         /// <param name="objName">The object's name.</param>
         /// <returns>A tuple containing the object's correct name and category.</returns>
-        private static (string? name, CATEGORY category) getCorrectNameAndCategoryFromIndex(int index, string objName)
+        private static (string? name, CATEGORY category) GetCorrectNameAndCategoryFromIndex(int index, string objName)
         {
             // Check the index for known cases and return the corresponding name and category
             switch (index)
@@ -878,10 +878,10 @@ namespace stardew_access.Utils
         /// <param name="x">The x-coordinate of the tile.</param>
         /// <param name="y">The y-coordinate of the tile.</param>
         /// <returns>True if a mine down ladder is found at the specified tile, otherwise false.</returns>
-        public static bool isMineDownLadderAtTile(GameLocation currentLocation, int x, int y)
+        public static bool IsMineDownLadderAtTile(GameLocation currentLocation, int x, int y)
         {
-            return (currentLocation is Mine or MineShaft || currentLocation.Name == "SkullCave")
-&& CheckTileIndex(currentLocation, x, y, 173);
+            return (currentLocation is Mine or MineShaft || currentLocation.Name == "SkullCave") 
+                && CheckTileIndex(currentLocation, x, y, 173);
         }
 
         /// <summary>
@@ -891,10 +891,10 @@ namespace stardew_access.Utils
         /// <param name="x">The x-coordinate of the tile.</param>
         /// <param name="y">The y-coordinate of the tile.</param>
         /// <returns>True if a mine shaft is found at the specified tile, otherwise false.</returns>
-        public static bool isShaftAtTile(GameLocation currentLocation, int x, int y)
+        public static bool IsShaftAtTile(GameLocation currentLocation, int x, int y)
         {
             return (currentLocation is Mine or MineShaft || currentLocation.Name == "SkullCave")
-&& CheckTileIndex(currentLocation, x, y, 174);
+                && CheckTileIndex(currentLocation, x, y, 174);
         }
 
         /// <summary>
@@ -904,10 +904,10 @@ namespace stardew_access.Utils
         /// <param name="x">The x-coordinate of the tile.</param>
         /// <param name="y">The y-coordinate of the tile.</param>
         /// <returns>True if a mine up ladder is found at the specified tile, otherwise false.</returns>
-        public static bool isMineUpLadderAtTile(GameLocation currentLocation, int x, int y)
+        public static bool IsMineUpLadderAtTile(GameLocation currentLocation, int x, int y)
         {
             return (currentLocation is Mine or MineShaft || currentLocation.Name == "SkullCave")
-&& CheckTileIndex(currentLocation, x, y, 115);
+                && CheckTileIndex(currentLocation, x, y, 115);
         }
 
         /// <summary>
@@ -917,10 +917,10 @@ namespace stardew_access.Utils
         /// <param name="x">The x-coordinate of the tile.</param>
         /// <param name="y">The y-coordinate of the tile.</param>
         /// <returns>True if an elevator is found at the specified tile, otherwise false.</returns>
-        public static bool isElevatorAtTile(GameLocation currentLocation, int x, int y)
+        public static bool IsElevatorAtTile(GameLocation currentLocation, int x, int y)
         {
             return (currentLocation is Mine or MineShaft || currentLocation.Name == "SkullCave")
-&& CheckTileIndex(currentLocation, x, y, 112);
+                && CheckTileIndex(currentLocation, x, y, 112);
         }
 
         /// <summary>
@@ -930,7 +930,7 @@ namespace stardew_access.Utils
         /// <param name="x">The x-coordinate of the tile to check.</param>
         /// <param name="y">The y-coordinate of the tile to check.</param>
         /// <returns>A string containing the door information if a door is found at the specified tile; null if no door is found.</returns>
-        public static string? getDoorAtTile(GameLocation currentLocation, int x, int y)
+        public static string? GetDoorAtTile(GameLocation currentLocation, int x, int y)
         {
             // Create a Point object from the given tile coordinates
             Point tilePoint = new(x, y);
@@ -957,11 +957,11 @@ namespace stardew_access.Utils
         /// <param name="y">The y-coordinate of the tile to check.</param>
         /// <param name="lessInfo">Optional. If true, returns information only if the tile coordinates match the resource clump's origin. Default is false.</param>
         /// <returns>A string containing the resource clump information if a resource clump is found at the specified tile; null if no resource clump is found.</returns>
-        public static string? getResourceClumpAtTile(GameLocation currentLocation, int x, int y, bool lessInfo = false)
+        public static string? GetResourceClumpAtTile(GameLocation currentLocation, int x, int y, bool lessInfo = false)
         {
             // Check if the current location is Woods and handle stumps in woods separately
             if (currentLocation is Woods woods)
-                return getStumpsInWoods(woods, x, y, lessInfo);
+                return GetStumpsInWoods(woods, x, y, lessInfo);
 
             // Iterate through resource clumps in the location using a for loop for performance reasons
             for (int i = 0, count = currentLocation.resourceClumps.Count; i < count; i++)
@@ -988,7 +988,7 @@ namespace stardew_access.Utils
         /// <param name="y">The y-coordinate of the tile to check.</param>
         /// <param name="lessInfo">Optional. If true, returns information only if the tile coordinates match the stump's origin. Default is false.</param>
         /// <returns>A string containing the stump information if a stump is found at the specified tile; null if no stump is found.</returns>
-        public static string? getStumpsInWoods(Woods woods, int x, int y, bool lessInfo = false)
+        public static string? GetStumpsInWoods(Woods woods, int x, int y, bool lessInfo = false)
         {
             // Iterate through stumps in the Woods location
             foreach (var stump in woods.stumps)


### PR DESCRIPTION
Apply same refactoring method to new i18n code, removing all compiler warnings and suggestions again.
Remove .editorconfig rule hiding IDE1006; fix all instances of IDE1006 (Naming rule violation due to functions having inconsistent capitalization).
Since each of the 120+ instances of 1006 had to be individually fixed I put this off until the rebase merge with i18n was complete.