### PR TITLE
MacSpeech: Remove unicode charset definitions for function calls

### DIFF
--- a/stardew-access/ScreenReader/ScreenReaderMac.cs
+++ b/stardew-access/ScreenReader/ScreenReaderMac.cs
@@ -27,7 +27,7 @@ namespace stardew_access.ScreenReader
         //
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void init_speaker();
-        [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void speak(string text);
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void set_voice(Int32 index);
@@ -37,7 +37,7 @@ namespace stardew_access.ScreenReader
         private static extern void set_language(Int32 index);
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern UInt32 available_languages_count();
-        [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void get_voice_name(UInt32 idx, String pszOut);
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void set_volume(Single volume);
@@ -61,7 +61,7 @@ namespace stardew_access.ScreenReader
         //
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr make_speaker();
-        [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void speak_with(IntPtr speaker, String text);
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void set_voice_with(IntPtr speaker, Int32 index);
@@ -101,7 +101,7 @@ namespace stardew_access.ScreenReader
         private static extern void start_listening(IntPtr listener);
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void stop_listening(IntPtr listener);
-        [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void add_command(IntPtr listener, String command);
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void cleanup_listener(IntPtr listener);
@@ -190,7 +190,6 @@ namespace stardew_access.ScreenReader
             rt.Start(cts.Token);
             register_did_finish_speaking_callback(speaker, fscb);
             set_rate_with(speaker, MainClass.Config.MacSpeechRate);
-            Say("Mac screen reader ready", true);
         }
 
         public void CloseScreenReader()


### PR DESCRIPTION
This removes the *unicode* charset definitions for string arguments, since C# seems to pass them on properly. Unicode characters used to speak as expected.

With it set, only the first character of any text is spoken, which makes the mod unusable.