### PR TITLE
Fix CA2101 for the Mac screen reader

### DIFF
--- a/stardew-access/ScreenReader/ScreenReaderMac.cs
+++ b/stardew-access/ScreenReader/ScreenReaderMac.cs
@@ -27,8 +27,8 @@ namespace stardew_access.ScreenReader
         //
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void init_speaker();
-        [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void speak(string text);
+        [DllImport("libspeak", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        private static extern void speak(String text);
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void set_voice(Int32 index);
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
@@ -37,7 +37,7 @@ namespace stardew_access.ScreenReader
         private static extern void set_language(Int32 index);
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern UInt32 available_languages_count();
-        [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libspeak",  CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         private static extern void get_voice_name(UInt32 idx, String pszOut);
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void set_volume(Single volume);
@@ -61,8 +61,8 @@ namespace stardew_access.ScreenReader
         //
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr make_speaker();
-        [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void speak_with(IntPtr speaker, String text);
+        [DllImport("libspeak", CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true, CallingConvention = CallingConvention.Cdecl)]
+        private static extern void speak_with(IntPtr speaker, [MarshalAs(UnmanagedType.LPUTF8Str)] String text);
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void set_voice_with(IntPtr speaker, Int32 index);
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
@@ -101,7 +101,7 @@ namespace stardew_access.ScreenReader
         private static extern void start_listening(IntPtr listener);
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void stop_listening(IntPtr listener);
-        [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libspeak", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         private static extern void add_command(IntPtr listener, String command);
         [DllImport("libspeak", CallingConvention = CallingConvention.Cdecl)]
         private static extern void cleanup_listener(IntPtr listener);


### PR DESCRIPTION
This fixes CA2101, specifying the marshaling type for strings and corrects c4dbfe1e for the Mac.

While https://github.com/khanshoaib3/stardew-access/pull/143 made the mod usable again, it did not take CA2101 into account.